### PR TITLE
Release main/Smdn.TPSmartHomeDevices.Primitives-1.0.1

### DIFF
--- a/doc/api-list/Smdn.TPSmartHomeDevices.Primitives/Smdn.TPSmartHomeDevices.Primitives-net6.0.apilist.cs
+++ b/doc/api-list/Smdn.TPSmartHomeDevices.Primitives/Smdn.TPSmartHomeDevices.Primitives-net6.0.apilist.cs
@@ -1,7 +1,7 @@
-// Smdn.TPSmartHomeDevices.Primitives.dll (Smdn.TPSmartHomeDevices.Primitives-1.0.0)
+// Smdn.TPSmartHomeDevices.Primitives.dll (Smdn.TPSmartHomeDevices.Primitives-1.0.1)
 //   Name: Smdn.TPSmartHomeDevices.Primitives
-//   AssemblyVersion: 1.0.0.0
-//   InformationalVersion: 1.0.0+2f8665ad485a16dee6305868cbf80f3089f4d60d
+//   AssemblyVersion: 1.0.1.0
+//   InformationalVersion: 1.0.1+934aee650dc331b389f51ddc76cb1f8042d47bf5
 //   TargetFramework: .NETCoreApp,Version=v6.0
 //   Configuration: Release
 //   Referenced assemblies:

--- a/doc/api-list/Smdn.TPSmartHomeDevices.Primitives/Smdn.TPSmartHomeDevices.Primitives-netstandard2.0.apilist.cs
+++ b/doc/api-list/Smdn.TPSmartHomeDevices.Primitives/Smdn.TPSmartHomeDevices.Primitives-netstandard2.0.apilist.cs
@@ -1,7 +1,7 @@
-// Smdn.TPSmartHomeDevices.Primitives.dll (Smdn.TPSmartHomeDevices.Primitives-1.0.0)
+// Smdn.TPSmartHomeDevices.Primitives.dll (Smdn.TPSmartHomeDevices.Primitives-1.0.1)
 //   Name: Smdn.TPSmartHomeDevices.Primitives
-//   AssemblyVersion: 1.0.0.0
-//   InformationalVersion: 1.0.0+2f8665ad485a16dee6305868cbf80f3089f4d60d
+//   AssemblyVersion: 1.0.1.0
+//   InformationalVersion: 1.0.1+934aee650dc331b389f51ddc76cb1f8042d47bf5
 //   TargetFramework: .NETStandard,Version=v2.0
 //   Configuration: Release
 //   Referenced assemblies:

--- a/doc/api-list/Smdn.TPSmartHomeDevices.Primitives/Smdn.TPSmartHomeDevices.Primitives-netstandard2.1.apilist.cs
+++ b/doc/api-list/Smdn.TPSmartHomeDevices.Primitives/Smdn.TPSmartHomeDevices.Primitives-netstandard2.1.apilist.cs
@@ -1,7 +1,7 @@
-// Smdn.TPSmartHomeDevices.Primitives.dll (Smdn.TPSmartHomeDevices.Primitives-1.0.0)
+// Smdn.TPSmartHomeDevices.Primitives.dll (Smdn.TPSmartHomeDevices.Primitives-1.0.1)
 //   Name: Smdn.TPSmartHomeDevices.Primitives
-//   AssemblyVersion: 1.0.0.0
-//   InformationalVersion: 1.0.0+2f8665ad485a16dee6305868cbf80f3089f4d60d
+//   AssemblyVersion: 1.0.1.0
+//   InformationalVersion: 1.0.1+934aee650dc331b389f51ddc76cb1f8042d47bf5
 //   TargetFramework: .NETStandard,Version=v2.1
 //   Configuration: Release
 //   Referenced assemblies:


### PR DESCRIPTION
Automatically generated by workflow [Generate release target #11](https://github.com/smdn/Smdn.TPSmartHomeDevices/actions/runs/4862703954).

# Release target
- package_target_tag: `new-release/main/Smdn.TPSmartHomeDevices.Primitives-1.0.1`
- package_prevver_ref: `releases/Smdn.TPSmartHomeDevices.Primitives-1.0.0`
- package_prevver_tag: `releases/Smdn.TPSmartHomeDevices.Primitives-1.0.0`
- package_id: `Smdn.TPSmartHomeDevices.Primitives`
- package_id_with_version: `Smdn.TPSmartHomeDevices.Primitives-1.0.1`
- package_version: `1.0.1`
- package_branch: `main`
- release_working_branch: `releases/Smdn.TPSmartHomeDevices.Primitives-1.0.1-1683039731`
- release_tag: `releases/Smdn.TPSmartHomeDevices.Primitives-1.0.1`
- release_prerelease: `False` ❗Change this value to `true` to publish release note as a prerelease.
- release_draft: `false` ❗Change this value to `true` to publish release note as a draft.
- release_note_url: [`https://gist.github.com/smdn/0acf21cf3e4ebc20c4a4b683f1ae70b4`](https://gist.github.com/smdn/0acf21cf3e4ebc20c4a4b683f1ae70b4)
- artifact_name_nupkg: `Smdn.TPSmartHomeDevices.Primitives.1.0.1.nupkg` ❗Remove this line or change this value to empty to prevent publishing packages.

# .nuspec diff
```diff
--- Smdn.TPSmartHomeDevices.Primitives.latest.nuspec
+++ Smdn.TPSmartHomeDevices.Primitives.1.0.1.nuspec
@@ -1,33 +1,43 @@
 <?xml version="1.0" encoding="utf-8"?>
-<package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
+<package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
   <metadata>
     <id>Smdn.TPSmartHomeDevices.Primitives</id>
-    <version>1.0.0</version>
+    <version>1.0.1</version>
     <title>Smdn.TPSmartHomeDevices.Primitives</title>
     <authors>smdn</authors>
     <license type="expression">MIT</license>
     <licenseUrl>https://licenses.nuget.org/MIT</licenseUrl>
     <icon>Smdn.TPSmartHomeDevices.Primitives.png</icon>
     <readme>README.md</readme>
     <projectUrl>https://github.com/smdn/Smdn.TPSmartHomeDevices/</projectUrl>
     <description>Provides common types for Smdn.TPSmartHomeDevices.Tapo and Smdn.TPSmartHomeDevices.Kasa, including abstraction interfaces, extension methods and custom JsonConverter's. This library does not provide any specific implementations to operate Kasa and Tapo devices.</description>
-    <releaseNotes>https://github.com/smdn/Smdn.TPSmartHomeDevices/releases/tag/releases%2FSmdn.TPSmartHomeDevices.Primitives-1.0.0</releaseNotes>
+    <releaseNotes>https://github.com/smdn/Smdn.TPSmartHomeDevices/releases/tag/releases%2FSmdn.TPSmartHomeDevices.Primitives-1.0.1</releaseNotes>
     <copyright>Copyright © 2023 smdn</copyright>
     <tags>smdn.jp tplink-kasa,kasa,tplink-tapo,tapo,common,smarthome,homeautomation,smartdevice</tags>
-    <repository type="git" url="https://github.com/smdn/Smdn.TPSmartHomeDevices" branch="main" commit="2f8665ad485a16dee6305868cbf80f3089f4d60d" />
+    <repository type="git" url="https://github.com/smdn/Smdn.TPSmartHomeDevices" commit="934aee650dc331b389f51ddc76cb1f8042d47bf5" />
     <dependencies>
       <group targetFramework="net6.0">
         <dependency id="Microsoft.Extensions.DependencyInjection.Abstractions" version="6.0.0" exclude="Build,Analyzers" />
         <dependency id="System.Text.Json" version="6.0.0" exclude="Build,Analyzers" />
       </group>
       <group targetFramework=".NETStandard2.0">
         <dependency id="Microsoft.Extensions.DependencyInjection.Abstractions" version="6.0.0" exclude="Build,Analyzers" />
         <dependency id="System.Text.Json" version="6.0.0" exclude="Build,Analyzers" />
       </group>
       <group targetFramework=".NETStandard2.1">
         <dependency id="Microsoft.Extensions.DependencyInjection.Abstractions" version="6.0.0" exclude="Build,Analyzers" />
         <dependency id="System.Text.Json" version="6.0.0" exclude="Build,Analyzers" />
       </group>
     </dependencies>
   </metadata>
+  <files>
+    <file src="/home/runner/work/Smdn.TPSmartHomeDevices/Smdn.TPSmartHomeDevices/src/Smdn.TPSmartHomeDevices.Primitives/bin/Release/net6.0/Smdn.TPSmartHomeDevices.Primitives.dll" target="lib/net6.0/Smdn.TPSmartHomeDevices.Primitives.dll" />
+    <file src="/home/runner/work/Smdn.TPSmartHomeDevices/Smdn.TPSmartHomeDevices/src/Smdn.TPSmartHomeDevices.Primitives/bin/Release/net6.0/Smdn.TPSmartHomeDevices.Primitives.xml" target="lib/net6.0/Smdn.TPSmartHomeDevices.Primitives.xml" />
+    <file src="/home/runner/work/Smdn.TPSmartHomeDevices/Smdn.TPSmartHomeDevices/src/Smdn.TPSmartHomeDevices.Primitives/bin/Release/netstandard2.0/Smdn.TPSmartHomeDevices.Primitives.dll" target="lib/netstandard2.0/Smdn.TPSmartHomeDevices.Primitives.dll" />
+    <file src="/home/runner/work/Smdn.TPSmartHomeDevices/Smdn.TPSmartHomeDevices/src/Smdn.TPSmartHomeDevices.Primitives/bin/Release/netstandard2.0/Smdn.TPSmartHomeDevices.Primitives.xml" target="lib/netstandard2.0/Smdn.TPSmartHomeDevices.Primitives.xml" />
+    <file src="/home/runner/work/Smdn.TPSmartHomeDevices/Smdn.TPSmartHomeDevices/src/Smdn.TPSmartHomeDevices.Primitives/bin/Release/netstandard2.1/Smdn.TPSmartHomeDevices.Primitives.dll" target="lib/netstandard2.1/Smdn.TPSmartHomeDevices.Primitives.dll" />
+    <file src="/home/runner/work/Smdn.TPSmartHomeDevices/Smdn.TPSmartHomeDevices/src/Smdn.TPSmartHomeDevices.Primitives/bin/Release/netstandard2.1/Smdn.TPSmartHomeDevices.Primitives.xml" target="lib/netstandard2.1/Smdn.TPSmartHomeDevices.Primitives.xml" />
+    <file src="/home/runner/work/Smdn.TPSmartHomeDevices/Smdn.TPSmartHomeDevices/.nuget/packages/smdn.msbuild.projectassets.common/1.3.5/project/images/package-icon.png" target="Smdn.TPSmartHomeDevices.Primitives.png" />
+    <file src="/home/runner/work/Smdn.TPSmartHomeDevices/Smdn.TPSmartHomeDevices/src/Smdn.TPSmartHomeDevices.Primitives/bin/Release/README.md" target="README.md" />
+  </files>
 </package>
\ No newline at end of file
```

