### PR TITLE
Release main/Smdn.TPSmartHomeDevices.Kasa-1.0.0

### DIFF
--- a/doc/api-list/Smdn.TPSmartHomeDevices.Kasa/Smdn.TPSmartHomeDevices.Kasa-net6.0.apilist.cs
+++ b/doc/api-list/Smdn.TPSmartHomeDevices.Kasa/Smdn.TPSmartHomeDevices.Kasa-net6.0.apilist.cs
@@ -1,7 +1,7 @@
-// Smdn.TPSmartHomeDevices.Kasa.dll (Smdn.TPSmartHomeDevices.Kasa-1.0.0-rc1)
+// Smdn.TPSmartHomeDevices.Kasa.dll (Smdn.TPSmartHomeDevices.Kasa-1.0.0)
 //   Name: Smdn.TPSmartHomeDevices.Kasa
 //   AssemblyVersion: 1.0.0.0
-//   InformationalVersion: 1.0.0-rc1+00727d1f82dcb2b9dd9c6e586f6c54110349bf48
+//   InformationalVersion: 1.0.0+4dd7eda1e01a411bacbd6593ca050a45b3c57c37
 //   TargetFramework: .NETCoreApp,Version=v6.0
 //   Configuration: Release
 //   Referenced assemblies:
@@ -29,6 +29,7 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Smdn.TPSmartHomeDevices;
 using Smdn.TPSmartHomeDevices.Kasa;
@@ -79,10 +80,10 @@ namespace Smdn.TPSmartHomeDevices.Kasa {
     public static KasaDevice Create(string host, IServiceProvider? serviceProvider = null) {}
     public static KasaDevice Create<TAddress>(TAddress deviceAddress, IServiceProvider serviceProvider) where TAddress : notnull {}
 
-    protected KasaDevice(IDeviceEndPoint deviceEndPoint, IServiceProvider? serviceProvider = null) {}
-    protected KasaDevice(IPAddress ipAddress, IServiceProvider? serviceProvider = null) {}
+    protected KasaDevice(IDeviceEndPoint deviceEndPoint, IServiceProvider? serviceProvider) {}
+    protected KasaDevice(IPAddress ipAddress, IServiceProvider? serviceProvider) {}
     protected KasaDevice(PhysicalAddress macAddress, IServiceProvider serviceProvider) {}
-    protected KasaDevice(string host, IServiceProvider? serviceProvider = null) {}
+    protected KasaDevice(string host, IServiceProvider? serviceProvider) {}
 
     public bool IsConnected { get; }
     [MemberNotNullWhen(false, "deviceEndPoint")]
@@ -94,6 +95,7 @@ namespace Smdn.TPSmartHomeDevices.Kasa {
     protected ValueTask SendRequestAsync<TMethodParameter>(JsonEncodedText module, JsonEncodedText method, TMethodParameter parameters, CancellationToken cancellationToken) {}
     protected ValueTask<TMethodResult> SendRequestAsync<TMethodParameter, TMethodResult>(JsonEncodedText module, JsonEncodedText method, TMethodParameter parameters, Func<JsonElement, TMethodResult> composeResult, CancellationToken cancellationToken) {}
     protected ValueTask<TMethodResult> SendRequestAsync<TMethodResult>(JsonEncodedText module, JsonEncodedText method, Func<JsonElement, TMethodResult> composeResult, CancellationToken cancellationToken) {}
+    public override string? ToString() {}
   }
 
   public abstract class KasaDeviceExceptionHandler {
@@ -102,6 +104,10 @@ namespace Smdn.TPSmartHomeDevices.Kasa {
     protected KasaDeviceExceptionHandler() {}
 
     public abstract KasaDeviceExceptionHandling DetermineHandling(KasaDevice device, Exception exception, int attempt, ILogger? logger);
+  }
+
+  public static class KasaDeviceExceptionHandlerServiceCollectionExtensions {
+    public static IServiceCollection AddKasaDeviceExceptionHandler(this IServiceCollection services, KasaDeviceExceptionHandler exceptionHandler) {}
   }
 
   public class KasaDisconnectedException : KasaProtocolException {

--- a/doc/api-list/Smdn.TPSmartHomeDevices.Kasa/Smdn.TPSmartHomeDevices.Kasa-net7.0.apilist.cs
+++ b/doc/api-list/Smdn.TPSmartHomeDevices.Kasa/Smdn.TPSmartHomeDevices.Kasa-net7.0.apilist.cs
@@ -1,7 +1,7 @@
-// Smdn.TPSmartHomeDevices.Kasa.dll (Smdn.TPSmartHomeDevices.Kasa-1.0.0-rc1)
+// Smdn.TPSmartHomeDevices.Kasa.dll (Smdn.TPSmartHomeDevices.Kasa-1.0.0)
 //   Name: Smdn.TPSmartHomeDevices.Kasa
 //   AssemblyVersion: 1.0.0.0
-//   InformationalVersion: 1.0.0-rc1+00727d1f82dcb2b9dd9c6e586f6c54110349bf48
+//   InformationalVersion: 1.0.0+4dd7eda1e01a411bacbd6593ca050a45b3c57c37
 //   TargetFramework: .NETCoreApp,Version=v7.0
 //   Configuration: Release
 //   Referenced assemblies:
@@ -29,6 +29,7 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Smdn.TPSmartHomeDevices;
 using Smdn.TPSmartHomeDevices.Kasa;
@@ -79,10 +80,10 @@ namespace Smdn.TPSmartHomeDevices.Kasa {
     public static KasaDevice Create(string host, IServiceProvider? serviceProvider = null) {}
     public static KasaDevice Create<TAddress>(TAddress deviceAddress, IServiceProvider serviceProvider) where TAddress : notnull {}
 
-    protected KasaDevice(IDeviceEndPoint deviceEndPoint, IServiceProvider? serviceProvider = null) {}
-    protected KasaDevice(IPAddress ipAddress, IServiceProvider? serviceProvider = null) {}
+    protected KasaDevice(IDeviceEndPoint deviceEndPoint, IServiceProvider? serviceProvider) {}
+    protected KasaDevice(IPAddress ipAddress, IServiceProvider? serviceProvider) {}
     protected KasaDevice(PhysicalAddress macAddress, IServiceProvider serviceProvider) {}
-    protected KasaDevice(string host, IServiceProvider? serviceProvider = null) {}
+    protected KasaDevice(string host, IServiceProvider? serviceProvider) {}
 
     public bool IsConnected { get; }
     [MemberNotNullWhen(false, "deviceEndPoint")]
@@ -94,6 +95,7 @@ namespace Smdn.TPSmartHomeDevices.Kasa {
     protected ValueTask SendRequestAsync<TMethodParameter>(JsonEncodedText module, JsonEncodedText method, TMethodParameter parameters, CancellationToken cancellationToken) {}
     protected ValueTask<TMethodResult> SendRequestAsync<TMethodParameter, TMethodResult>(JsonEncodedText module, JsonEncodedText method, TMethodParameter parameters, Func<JsonElement, TMethodResult> composeResult, CancellationToken cancellationToken) {}
     protected ValueTask<TMethodResult> SendRequestAsync<TMethodResult>(JsonEncodedText module, JsonEncodedText method, Func<JsonElement, TMethodResult> composeResult, CancellationToken cancellationToken) {}
+    public override string? ToString() {}
   }
 
   public abstract class KasaDeviceExceptionHandler {
@@ -102,6 +104,10 @@ namespace Smdn.TPSmartHomeDevices.Kasa {
     protected KasaDeviceExceptionHandler() {}
 
     public abstract KasaDeviceExceptionHandling DetermineHandling(KasaDevice device, Exception exception, int attempt, ILogger? logger);
+  }
+
+  public static class KasaDeviceExceptionHandlerServiceCollectionExtensions {
+    public static IServiceCollection AddKasaDeviceExceptionHandler(this IServiceCollection services, KasaDeviceExceptionHandler exceptionHandler) {}
   }
 
   public class KasaDisconnectedException : KasaProtocolException {

--- a/doc/api-list/Smdn.TPSmartHomeDevices.Kasa/Smdn.TPSmartHomeDevices.Kasa-netstandard2.1.apilist.cs
+++ b/doc/api-list/Smdn.TPSmartHomeDevices.Kasa/Smdn.TPSmartHomeDevices.Kasa-netstandard2.1.apilist.cs
@@ -1,7 +1,7 @@
-// Smdn.TPSmartHomeDevices.Kasa.dll (Smdn.TPSmartHomeDevices.Kasa-1.0.0-rc1)
+// Smdn.TPSmartHomeDevices.Kasa.dll (Smdn.TPSmartHomeDevices.Kasa-1.0.0)
 //   Name: Smdn.TPSmartHomeDevices.Kasa
 //   AssemblyVersion: 1.0.0.0
-//   InformationalVersion: 1.0.0-rc1+00727d1f82dcb2b9dd9c6e586f6c54110349bf48
+//   InformationalVersion: 1.0.0+4dd7eda1e01a411bacbd6593ca050a45b3c57c37
 //   TargetFramework: .NETStandard,Version=v2.1
 //   Configuration: Release
 //   Referenced assemblies:
@@ -21,6 +21,7 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Smdn.TPSmartHomeDevices;
 using Smdn.TPSmartHomeDevices.Kasa;
@@ -71,10 +72,10 @@ namespace Smdn.TPSmartHomeDevices.Kasa {
     public static KasaDevice Create(string host, IServiceProvider? serviceProvider = null) {}
     public static KasaDevice Create<TAddress>(TAddress deviceAddress, IServiceProvider serviceProvider) where TAddress : notnull {}
 
-    protected KasaDevice(IDeviceEndPoint deviceEndPoint, IServiceProvider? serviceProvider = null) {}
-    protected KasaDevice(IPAddress ipAddress, IServiceProvider? serviceProvider = null) {}
+    protected KasaDevice(IDeviceEndPoint deviceEndPoint, IServiceProvider? serviceProvider) {}
+    protected KasaDevice(IPAddress ipAddress, IServiceProvider? serviceProvider) {}
     protected KasaDevice(PhysicalAddress macAddress, IServiceProvider serviceProvider) {}
-    protected KasaDevice(string host, IServiceProvider? serviceProvider = null) {}
+    protected KasaDevice(string host, IServiceProvider? serviceProvider) {}
 
     public bool IsConnected { get; }
     protected bool IsDisposed { get; }
@@ -85,6 +86,7 @@ namespace Smdn.TPSmartHomeDevices.Kasa {
     protected ValueTask SendRequestAsync<TMethodParameter>(JsonEncodedText module, JsonEncodedText method, TMethodParameter parameters, CancellationToken cancellationToken) {}
     protected ValueTask<TMethodResult> SendRequestAsync<TMethodParameter, TMethodResult>(JsonEncodedText module, JsonEncodedText method, TMethodParameter parameters, Func<JsonElement, TMethodResult> composeResult, CancellationToken cancellationToken) {}
     protected ValueTask<TMethodResult> SendRequestAsync<TMethodResult>(JsonEncodedText module, JsonEncodedText method, Func<JsonElement, TMethodResult> composeResult, CancellationToken cancellationToken) {}
+    public override string? ToString() {}
   }
 
   public abstract class KasaDeviceExceptionHandler {
@@ -93,6 +95,10 @@ namespace Smdn.TPSmartHomeDevices.Kasa {
     protected KasaDeviceExceptionHandler() {}
 
     public abstract KasaDeviceExceptionHandling DetermineHandling(KasaDevice device, Exception exception, int attempt, ILogger? logger);
+  }
+
+  public static class KasaDeviceExceptionHandlerServiceCollectionExtensions {
+    public static IServiceCollection AddKasaDeviceExceptionHandler(this IServiceCollection services, KasaDeviceExceptionHandler exceptionHandler) {}
   }
 
   public class KasaDisconnectedException : KasaProtocolException {


### PR DESCRIPTION
Automatically generated by workflow [Generate release target #13](https://github.com/smdn/Smdn.TPSmartHomeDevices/actions/runs/4863064839).

# Release target
- package_target_tag: `new-release/main/Smdn.TPSmartHomeDevices.Kasa-1.0.0`
- package_prevver_ref: `releases/Smdn.TPSmartHomeDevices.Kasa-1.0.0-rc1`
- package_prevver_tag: `releases/Smdn.TPSmartHomeDevices.Kasa-1.0.0-rc1`
- package_id: `Smdn.TPSmartHomeDevices.Kasa`
- package_id_with_version: `Smdn.TPSmartHomeDevices.Kasa-1.0.0`
- package_version: `1.0.0`
- package_branch: `main`
- release_working_branch: `releases/Smdn.TPSmartHomeDevices.Kasa-1.0.0-1683041903`
- release_tag: `releases/Smdn.TPSmartHomeDevices.Kasa-1.0.0`
- release_prerelease: `False` ❗Change this value to `true` to publish release note as a prerelease.
- release_draft: `false` ❗Change this value to `true` to publish release note as a draft.
- release_note_url: [`https://gist.github.com/smdn/d5aa87731fd769c7ca66dc4647ff7044`](https://gist.github.com/smdn/d5aa87731fd769c7ca66dc4647ff7044)
- artifact_name_nupkg: `Smdn.TPSmartHomeDevices.Kasa.1.0.0.nupkg` ❗Remove this line or change this value to empty to prevent publishing packages.


