### PR TITLE
Release main/Smdn.TPSmartHomeDevices.MacAddressEndPoint-1.0.0

### DIFF
--- a/doc/api-list/Smdn.TPSmartHomeDevices.MacAddressEndPoint/Smdn.TPSmartHomeDevices.MacAddressEndPoint-net6.0.apilist.cs
+++ b/doc/api-list/Smdn.TPSmartHomeDevices.MacAddressEndPoint/Smdn.TPSmartHomeDevices.MacAddressEndPoint-net6.0.apilist.cs
@@ -1,7 +1,7 @@
-// Smdn.TPSmartHomeDevices.MacAddressEndPoint.dll (Smdn.TPSmartHomeDevices.MacAddressEndPoint-1.0.0-rc1)
+// Smdn.TPSmartHomeDevices.MacAddressEndPoint.dll (Smdn.TPSmartHomeDevices.MacAddressEndPoint-1.0.0)
 //   Name: Smdn.TPSmartHomeDevices.MacAddressEndPoint
 //   AssemblyVersion: 1.0.0.0
-//   InformationalVersion: 1.0.0-rc1+00727d1f82dcb2b9dd9c6e586f6c54110349bf48
+//   InformationalVersion: 1.0.0+4dd7eda1e01a411bacbd6593ca050a45b3c57c37
 //   TargetFramework: .NETCoreApp,Version=v6.0
 //   Configuration: Release
 //   Referenced assemblies:

--- a/doc/api-list/Smdn.TPSmartHomeDevices.MacAddressEndPoint/Smdn.TPSmartHomeDevices.MacAddressEndPoint-net7.0.apilist.cs
+++ b/doc/api-list/Smdn.TPSmartHomeDevices.MacAddressEndPoint/Smdn.TPSmartHomeDevices.MacAddressEndPoint-net7.0.apilist.cs
@@ -1,7 +1,7 @@
-// Smdn.TPSmartHomeDevices.MacAddressEndPoint.dll (Smdn.TPSmartHomeDevices.MacAddressEndPoint-1.0.0-rc1)
+// Smdn.TPSmartHomeDevices.MacAddressEndPoint.dll (Smdn.TPSmartHomeDevices.MacAddressEndPoint-1.0.0)
 //   Name: Smdn.TPSmartHomeDevices.MacAddressEndPoint
 //   AssemblyVersion: 1.0.0.0
-//   InformationalVersion: 1.0.0-rc1+00727d1f82dcb2b9dd9c6e586f6c54110349bf48
+//   InformationalVersion: 1.0.0+4dd7eda1e01a411bacbd6593ca050a45b3c57c37
 //   TargetFramework: .NETCoreApp,Version=v7.0
 //   Configuration: Release
 //   Referenced assemblies:

--- a/doc/api-list/Smdn.TPSmartHomeDevices.MacAddressEndPoint/Smdn.TPSmartHomeDevices.MacAddressEndPoint-netstandard2.0.apilist.cs
+++ b/doc/api-list/Smdn.TPSmartHomeDevices.MacAddressEndPoint/Smdn.TPSmartHomeDevices.MacAddressEndPoint-netstandard2.0.apilist.cs
@@ -1,7 +1,7 @@
-// Smdn.TPSmartHomeDevices.MacAddressEndPoint.dll (Smdn.TPSmartHomeDevices.MacAddressEndPoint-1.0.0-rc1)
+// Smdn.TPSmartHomeDevices.MacAddressEndPoint.dll (Smdn.TPSmartHomeDevices.MacAddressEndPoint-1.0.0)
 //   Name: Smdn.TPSmartHomeDevices.MacAddressEndPoint
 //   AssemblyVersion: 1.0.0.0
-//   InformationalVersion: 1.0.0-rc1+00727d1f82dcb2b9dd9c6e586f6c54110349bf48
+//   InformationalVersion: 1.0.0+4dd7eda1e01a411bacbd6593ca050a45b3c57c37
 //   TargetFramework: .NETStandard,Version=v2.0
 //   Configuration: Release
 //   Referenced assemblies:

--- a/doc/api-list/Smdn.TPSmartHomeDevices.MacAddressEndPoint/Smdn.TPSmartHomeDevices.MacAddressEndPoint-netstandard2.1.apilist.cs
+++ b/doc/api-list/Smdn.TPSmartHomeDevices.MacAddressEndPoint/Smdn.TPSmartHomeDevices.MacAddressEndPoint-netstandard2.1.apilist.cs
@@ -1,7 +1,7 @@
-// Smdn.TPSmartHomeDevices.MacAddressEndPoint.dll (Smdn.TPSmartHomeDevices.MacAddressEndPoint-1.0.0-rc1)
+// Smdn.TPSmartHomeDevices.MacAddressEndPoint.dll (Smdn.TPSmartHomeDevices.MacAddressEndPoint-1.0.0)
 //   Name: Smdn.TPSmartHomeDevices.MacAddressEndPoint
 //   AssemblyVersion: 1.0.0.0
-//   InformationalVersion: 1.0.0-rc1+00727d1f82dcb2b9dd9c6e586f6c54110349bf48
+//   InformationalVersion: 1.0.0+4dd7eda1e01a411bacbd6593ca050a45b3c57c37
 //   TargetFramework: .NETStandard,Version=v2.1
 //   Configuration: Release
 //   Referenced assemblies:


### PR DESCRIPTION
Automatically generated by workflow [Generate release target #14](https://github.com/smdn/Smdn.TPSmartHomeDevices/actions/runs/4863134618).

# Release target
- package_target_tag: `new-release/main/Smdn.TPSmartHomeDevices.MacAddressEndPoint-1.0.0`
- package_prevver_ref: `releases/Smdn.TPSmartHomeDevices.MacAddressEndPoint-1.0.0-rc1`
- package_prevver_tag: `releases/Smdn.TPSmartHomeDevices.MacAddressEndPoint-1.0.0-rc1`
- package_id: `Smdn.TPSmartHomeDevices.MacAddressEndPoint`
- package_id_with_version: `Smdn.TPSmartHomeDevices.MacAddressEndPoint-1.0.0`
- package_version: `1.0.0`
- package_branch: `main`
- release_working_branch: `releases/Smdn.TPSmartHomeDevices.MacAddressEndPoint-1.0.0-1683042387`
- release_tag: `releases/Smdn.TPSmartHomeDevices.MacAddressEndPoint-1.0.0`
- release_prerelease: `False` ❗Change this value to `true` to publish release note as a prerelease.
- release_draft: `false` ❗Change this value to `true` to publish release note as a draft.
- release_note_url: [`https://gist.github.com/smdn/e5bf15379077f493e8c2f70d3c0af4a2`](https://gist.github.com/smdn/e5bf15379077f493e8c2f70d3c0af4a2)
- artifact_name_nupkg: `Smdn.TPSmartHomeDevices.MacAddressEndPoint.1.0.0.nupkg` ❗Remove this line or change this value to empty to prevent publishing packages.


