### PR TITLE
Release main/Smdn.TPSmartHomeDevices.MacAddressEndPoint-1.1.0

### DIFF
--- a/doc/api-list/Smdn.TPSmartHomeDevices.MacAddressEndPoint/Smdn.TPSmartHomeDevices.MacAddressEndPoint-net6.0.apilist.cs
+++ b/doc/api-list/Smdn.TPSmartHomeDevices.MacAddressEndPoint/Smdn.TPSmartHomeDevices.MacAddressEndPoint-net6.0.apilist.cs
@@ -1,7 +1,7 @@
-// Smdn.TPSmartHomeDevices.MacAddressEndPoint.dll (Smdn.TPSmartHomeDevices.MacAddressEndPoint-1.0.0)
+// Smdn.TPSmartHomeDevices.MacAddressEndPoint.dll (Smdn.TPSmartHomeDevices.MacAddressEndPoint-1.1.0)
 //   Name: Smdn.TPSmartHomeDevices.MacAddressEndPoint
-//   AssemblyVersion: 1.0.0.0
-//   InformationalVersion: 1.0.0+4dd7eda1e01a411bacbd6593ca050a45b3c57c37
+//   AssemblyVersion: 1.1.0.0
+//   InformationalVersion: 1.1.0+26b3994b9e663ddd0b4c39b0a86948a876d03dad
 //   TargetFramework: .NETCoreApp,Version=v6.0
 //   Configuration: Release
 //   Referenced assemblies:
@@ -35,9 +35,14 @@ namespace Smdn.TPSmartHomeDevices {
       public override string ToString() {}
     }
 
+    [Obsolete("Use an overload that specifies the parameter `shouldDisposeResolver`.")]
     protected MacAddressDeviceEndPointFactory(IAddressResolver<PhysicalAddress, IPAddress> resolver, IServiceProvider? serviceProvider = null) {}
+    protected MacAddressDeviceEndPointFactory(IAddressResolver<PhysicalAddress, IPAddress> resolver, bool shouldDisposeResolver, IServiceProvider? serviceProvider) {}
     public MacAddressDeviceEndPointFactory(IPNetworkProfile networkProfile, IServiceProvider? serviceProvider = null) {}
+    public MacAddressDeviceEndPointFactory(IPNetworkProfile networkProfile, TimeSpan networkScanInterval, TimeSpan networkScanMinInterval, IServiceProvider? serviceProvider = null) {}
+    [Obsolete("Use an overload that specifies the parameter `shouldDisposeResolver`.")]
     public MacAddressDeviceEndPointFactory(MacAddressResolverBase resolver, IServiceProvider? serviceProvider = null) {}
+    public MacAddressDeviceEndPointFactory(MacAddressResolverBase resolver, bool shouldDisposeResolver, IServiceProvider? serviceProvider = null) {}
 
     public virtual IDeviceEndPoint Create(PhysicalAddress address) {}
     protected virtual void Dispose(bool disposing) {}

--- a/doc/api-list/Smdn.TPSmartHomeDevices.MacAddressEndPoint/Smdn.TPSmartHomeDevices.MacAddressEndPoint-net7.0.apilist.cs
+++ b/doc/api-list/Smdn.TPSmartHomeDevices.MacAddressEndPoint/Smdn.TPSmartHomeDevices.MacAddressEndPoint-net7.0.apilist.cs
@@ -1,7 +1,7 @@
-// Smdn.TPSmartHomeDevices.MacAddressEndPoint.dll (Smdn.TPSmartHomeDevices.MacAddressEndPoint-1.0.0)
+// Smdn.TPSmartHomeDevices.MacAddressEndPoint.dll (Smdn.TPSmartHomeDevices.MacAddressEndPoint-1.1.0)
 //   Name: Smdn.TPSmartHomeDevices.MacAddressEndPoint
-//   AssemblyVersion: 1.0.0.0
-//   InformationalVersion: 1.0.0+4dd7eda1e01a411bacbd6593ca050a45b3c57c37
+//   AssemblyVersion: 1.1.0.0
+//   InformationalVersion: 1.1.0+26b3994b9e663ddd0b4c39b0a86948a876d03dad
 //   TargetFramework: .NETCoreApp,Version=v7.0
 //   Configuration: Release
 //   Referenced assemblies:
@@ -35,9 +35,14 @@ namespace Smdn.TPSmartHomeDevices {
       public override string ToString() {}
     }
 
+    [Obsolete("Use an overload that specifies the parameter `shouldDisposeResolver`.")]
     protected MacAddressDeviceEndPointFactory(IAddressResolver<PhysicalAddress, IPAddress> resolver, IServiceProvider? serviceProvider = null) {}
+    protected MacAddressDeviceEndPointFactory(IAddressResolver<PhysicalAddress, IPAddress> resolver, bool shouldDisposeResolver, IServiceProvider? serviceProvider) {}
     public MacAddressDeviceEndPointFactory(IPNetworkProfile networkProfile, IServiceProvider? serviceProvider = null) {}
+    public MacAddressDeviceEndPointFactory(IPNetworkProfile networkProfile, TimeSpan networkScanInterval, TimeSpan networkScanMinInterval, IServiceProvider? serviceProvider = null) {}
+    [Obsolete("Use an overload that specifies the parameter `shouldDisposeResolver`.")]
     public MacAddressDeviceEndPointFactory(MacAddressResolverBase resolver, IServiceProvider? serviceProvider = null) {}
+    public MacAddressDeviceEndPointFactory(MacAddressResolverBase resolver, bool shouldDisposeResolver, IServiceProvider? serviceProvider = null) {}
 
     public virtual IDeviceEndPoint Create(PhysicalAddress address) {}
     protected virtual void Dispose(bool disposing) {}

--- a/doc/api-list/Smdn.TPSmartHomeDevices.MacAddressEndPoint/Smdn.TPSmartHomeDevices.MacAddressEndPoint-netstandard2.0.apilist.cs
+++ b/doc/api-list/Smdn.TPSmartHomeDevices.MacAddressEndPoint/Smdn.TPSmartHomeDevices.MacAddressEndPoint-netstandard2.0.apilist.cs
@@ -1,7 +1,7 @@
-// Smdn.TPSmartHomeDevices.MacAddressEndPoint.dll (Smdn.TPSmartHomeDevices.MacAddressEndPoint-1.0.0)
+// Smdn.TPSmartHomeDevices.MacAddressEndPoint.dll (Smdn.TPSmartHomeDevices.MacAddressEndPoint-1.1.0)
 //   Name: Smdn.TPSmartHomeDevices.MacAddressEndPoint
-//   AssemblyVersion: 1.0.0.0
-//   InformationalVersion: 1.0.0+4dd7eda1e01a411bacbd6593ca050a45b3c57c37
+//   AssemblyVersion: 1.1.0.0
+//   InformationalVersion: 1.1.0+26b3994b9e663ddd0b4c39b0a86948a876d03dad
 //   TargetFramework: .NETStandard,Version=v2.0
 //   Configuration: Release
 //   Referenced assemblies:
@@ -33,9 +33,14 @@ namespace Smdn.TPSmartHomeDevices {
       public override string ToString() {}
     }
 
+    [Obsolete("Use an overload that specifies the parameter `shouldDisposeResolver`.")]
     protected MacAddressDeviceEndPointFactory(IAddressResolver<PhysicalAddress, IPAddress> resolver, IServiceProvider? serviceProvider = null) {}
+    protected MacAddressDeviceEndPointFactory(IAddressResolver<PhysicalAddress, IPAddress> resolver, bool shouldDisposeResolver, IServiceProvider? serviceProvider) {}
     public MacAddressDeviceEndPointFactory(IPNetworkProfile networkProfile, IServiceProvider? serviceProvider = null) {}
+    public MacAddressDeviceEndPointFactory(IPNetworkProfile networkProfile, TimeSpan networkScanInterval, TimeSpan networkScanMinInterval, IServiceProvider? serviceProvider = null) {}
+    [Obsolete("Use an overload that specifies the parameter `shouldDisposeResolver`.")]
     public MacAddressDeviceEndPointFactory(MacAddressResolverBase resolver, IServiceProvider? serviceProvider = null) {}
+    public MacAddressDeviceEndPointFactory(MacAddressResolverBase resolver, bool shouldDisposeResolver, IServiceProvider? serviceProvider = null) {}
 
     public virtual IDeviceEndPoint Create(PhysicalAddress address) {}
     protected virtual void Dispose(bool disposing) {}

--- a/doc/api-list/Smdn.TPSmartHomeDevices.MacAddressEndPoint/Smdn.TPSmartHomeDevices.MacAddressEndPoint-netstandard2.1.apilist.cs
+++ b/doc/api-list/Smdn.TPSmartHomeDevices.MacAddressEndPoint/Smdn.TPSmartHomeDevices.MacAddressEndPoint-netstandard2.1.apilist.cs
@@ -1,7 +1,7 @@
-// Smdn.TPSmartHomeDevices.MacAddressEndPoint.dll (Smdn.TPSmartHomeDevices.MacAddressEndPoint-1.0.0)
+// Smdn.TPSmartHomeDevices.MacAddressEndPoint.dll (Smdn.TPSmartHomeDevices.MacAddressEndPoint-1.1.0)
 //   Name: Smdn.TPSmartHomeDevices.MacAddressEndPoint
-//   AssemblyVersion: 1.0.0.0
-//   InformationalVersion: 1.0.0+4dd7eda1e01a411bacbd6593ca050a45b3c57c37
+//   AssemblyVersion: 1.1.0.0
+//   InformationalVersion: 1.1.0+26b3994b9e663ddd0b4c39b0a86948a876d03dad
 //   TargetFramework: .NETStandard,Version=v2.1
 //   Configuration: Release
 //   Referenced assemblies:
@@ -32,9 +32,14 @@ namespace Smdn.TPSmartHomeDevices {
       public override string ToString() {}
     }
 
+    [Obsolete("Use an overload that specifies the parameter `shouldDisposeResolver`.")]
     protected MacAddressDeviceEndPointFactory(IAddressResolver<PhysicalAddress, IPAddress> resolver, IServiceProvider? serviceProvider = null) {}
+    protected MacAddressDeviceEndPointFactory(IAddressResolver<PhysicalAddress, IPAddress> resolver, bool shouldDisposeResolver, IServiceProvider? serviceProvider) {}
     public MacAddressDeviceEndPointFactory(IPNetworkProfile networkProfile, IServiceProvider? serviceProvider = null) {}
+    public MacAddressDeviceEndPointFactory(IPNetworkProfile networkProfile, TimeSpan networkScanInterval, TimeSpan networkScanMinInterval, IServiceProvider? serviceProvider = null) {}
+    [Obsolete("Use an overload that specifies the parameter `shouldDisposeResolver`.")]
     public MacAddressDeviceEndPointFactory(MacAddressResolverBase resolver, IServiceProvider? serviceProvider = null) {}
+    public MacAddressDeviceEndPointFactory(MacAddressResolverBase resolver, bool shouldDisposeResolver, IServiceProvider? serviceProvider = null) {}
 
     public virtual IDeviceEndPoint Create(PhysicalAddress address) {}
     protected virtual void Dispose(bool disposing) {}


### PR DESCRIPTION
Automatically generated by workflow [Generate release target #16](https://github.com/smdn/Smdn.TPSmartHomeDevices/actions/runs/4972370442).

# Release target
- package_target_tag: `new-release/main/Smdn.TPSmartHomeDevices.MacAddressEndPoint-1.1.0`
- package_prevver_ref: `releases/Smdn.TPSmartHomeDevices.MacAddressEndPoint-1.0.0`
- package_prevver_tag: `releases/Smdn.TPSmartHomeDevices.MacAddressEndPoint-1.0.0`
- package_id: `Smdn.TPSmartHomeDevices.MacAddressEndPoint`
- package_id_with_version: `Smdn.TPSmartHomeDevices.MacAddressEndPoint-1.1.0`
- package_version: `1.1.0`
- package_branch: `main`
- release_working_branch: `releases/Smdn.TPSmartHomeDevices.MacAddressEndPoint-1.1.0-1684067478`
- release_tag: `releases/Smdn.TPSmartHomeDevices.MacAddressEndPoint-1.1.0`
- release_prerelease: `False` ❗Change this value to `true` to publish release note as a prerelease.
- release_draft: `false` ❗Change this value to `true` to publish release note as a draft.
- release_note_url: [`https://gist.github.com/smdn/cbcfc7ccea2423b77fa3fcfc9a1ac98a`](https://gist.github.com/smdn/cbcfc7ccea2423b77fa3fcfc9a1ac98a)
- artifact_name_nupkg: `Smdn.TPSmartHomeDevices.MacAddressEndPoint.1.1.0.nupkg` ❗Remove this line or change this value to empty to prevent publishing packages.

# .nuspec diff
```diff
--- Smdn.TPSmartHomeDevices.MacAddressEndPoint.latest.nuspec
+++ Smdn.TPSmartHomeDevices.MacAddressEndPoint.1.1.0.nuspec
@@ -1,37 +1,50 @@
 <?xml version="1.0" encoding="utf-8"?>
-<package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
+<package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
   <metadata>
     <id>Smdn.TPSmartHomeDevices.MacAddressEndPoint</id>
-    <version>1.0.0</version>
+    <version>1.1.0</version>
     <title>Smdn.TPSmartHomeDevices.MacAddressEndPoint</title>
     <authors>smdn</authors>
     <license type="expression">MIT</license>
     <licenseUrl>https://licenses.nuget.org/MIT</licenseUrl>
     <icon>Smdn.TPSmartHomeDevices.MacAddressEndPoint.png</icon>
     <readme>README.md</readme>
     <projectUrl>https://github.com/smdn/Smdn.TPSmartHomeDevices/</projectUrl>
     <description>An extension library to add a service to Smdn.TPSmartHomeDevices.Tapo and Smdn.TPSmartHomeDevices.Kasa that enables the resolution of devices' endpoints by MAC address.</description>
-    <releaseNotes>https://github.com/smdn/Smdn.TPSmartHomeDevices/releases/tag/releases%2FSmdn.TPSmartHomeDevices.MacAddressEndPoint-1.0.0</releaseNotes>
+    <releaseNotes>https://github.com/smdn/Smdn.TPSmartHomeDevices/releases/tag/releases%2FSmdn.TPSmartHomeDevices.MacAddressEndPoint-1.1.0</releaseNotes>
     <copyright>Copyright © 2023 smdn</copyright>
     <tags>smdn.jp tplink-kasa,kasa,tplink-tapo,tapo,mac-address,address-resolution,smarthome,homeautomation,smartdevice</tags>
-    <repository type="git" url="https://github.com/smdn/Smdn.TPSmartHomeDevices" branch="main" commit="4dd7eda1e01a411bacbd6593ca050a45b3c57c37" />
+    <repository type="git" url="https://github.com/smdn/Smdn.TPSmartHomeDevices" commit="26b3994b9e663ddd0b4c39b0a86948a876d03dad" />
     <dependencies>
       <group targetFramework="net6.0">
         <dependency id="Smdn.Net.AddressResolution" version="1.0.0" exclude="Build,Analyzers" />
         <dependency id="Smdn.TPSmartHomeDevices.Primitives" version="[1.0.0, 2.0.0)" exclude="Build,Analyzers" />
       </group>
       <group targetFramework="net7.0">
         <dependency id="Smdn.Net.AddressResolution" version="1.0.0" exclude="Build,Analyzers" />
         <dependency id="Smdn.TPSmartHomeDevices.Primitives" version="[1.0.0, 2.0.0)" exclude="Build,Analyzers" />
       </group>
       <group targetFramework=".NETStandard2.0">
         <dependency id="Smdn.Net.AddressResolution" version="1.0.0" exclude="Build,Analyzers" />
         <dependency id="Smdn.TPSmartHomeDevices.Primitives" version="[1.0.0, 2.0.0)" exclude="Build,Analyzers" />
       </group>
       <group targetFramework=".NETStandard2.1">
         <dependency id="Smdn.Net.AddressResolution" version="1.0.0" exclude="Build,Analyzers" />
         <dependency id="Smdn.TPSmartHomeDevices.Primitives" version="[1.0.0, 2.0.0)" exclude="Build,Analyzers" />
       </group>
     </dependencies>
   </metadata>
+  <files>
+    <file src="/home/runner/work/Smdn.TPSmartHomeDevices/Smdn.TPSmartHomeDevices/src/Smdn.TPSmartHomeDevices.MacAddressEndPoint/bin/Release/net6.0/Smdn.TPSmartHomeDevices.MacAddressEndPoint.dll" target="lib/net6.0/Smdn.TPSmartHomeDevices.MacAddressEndPoint.dll" />
+    <file src="/home/runner/work/Smdn.TPSmartHomeDevices/Smdn.TPSmartHomeDevices/src/Smdn.TPSmartHomeDevices.MacAddressEndPoint/bin/Release/net6.0/Smdn.TPSmartHomeDevices.MacAddressEndPoint.xml" target="lib/net6.0/Smdn.TPSmartHomeDevices.MacAddressEndPoint.xml" />
+    <file src="/home/runner/work/Smdn.TPSmartHomeDevices/Smdn.TPSmartHomeDevices/src/Smdn.TPSmartHomeDevices.MacAddressEndPoint/bin/Release/net7.0/Smdn.TPSmartHomeDevices.MacAddressEndPoint.dll" target="lib/net7.0/Smdn.TPSmartHomeDevices.MacAddressEndPoint.dll" />
+    <file src="/home/runner/work/Smdn.TPSmartHomeDevices/Smdn.TPSmartHomeDevices/src/Smdn.TPSmartHomeDevices.MacAddressEndPoint/bin/Release/net7.0/Smdn.TPSmartHomeDevices.MacAddressEndPoint.xml" target="lib/net7.0/Smdn.TPSmartHomeDevices.MacAddressEndPoint.xml" />
+    <file src="/home/runner/work/Smdn.TPSmartHomeDevices/Smdn.TPSmartHomeDevices/src/Smdn.TPSmartHomeDevices.MacAddressEndPoint/bin/Release/netstandard2.0/Smdn.TPSmartHomeDevices.MacAddressEndPoint.dll" target="lib/netstandard2.0/Smdn.TPSmartHomeDevices.MacAddressEndPoint.dll" />
+    <file src="/home/runner/work/Smdn.TPSmartHomeDevices/Smdn.TPSmartHomeDevices/src/Smdn.TPSmartHomeDevices.MacAddressEndPoint/bin/Release/netstandard2.0/Smdn.TPSmartHomeDevices.MacAddressEndPoint.xml" target="lib/netstandard2.0/Smdn.TPSmartHomeDevices.MacAddressEndPoint.xml" />
+    <file src="/home/runner/work/Smdn.TPSmartHomeDevices/Smdn.TPSmartHomeDevices/src/Smdn.TPSmartHomeDevices.MacAddressEndPoint/bin/Release/netstandard2.1/Smdn.TPSmartHomeDevices.MacAddressEndPoint.dll" target="lib/netstandard2.1/Smdn.TPSmartHomeDevices.MacAddressEndPoint.dll" />
+    <file src="/home/runner/work/Smdn.TPSmartHomeDevices/Smdn.TPSmartHomeDevices/src/Smdn.TPSmartHomeDevices.MacAddressEndPoint/bin/Release/netstandard2.1/Smdn.TPSmartHomeDevices.MacAddressEndPoint.xml" target="lib/netstandard2.1/Smdn.TPSmartHomeDevices.MacAddressEndPoint.xml" />
+    <file src="/home/runner/work/Smdn.TPSmartHomeDevices/Smdn.TPSmartHomeDevices/.nuget/packages/smdn.msbuild.projectassets.common/1.3.6/project/images/package-icon.png" target="Smdn.TPSmartHomeDevices.MacAddressEndPoint.png" />
+    <file src="/home/runner/work/Smdn.TPSmartHomeDevices/Smdn.TPSmartHomeDevices/ThirdPartyNotices.md" target="ThirdPartyNotices.md" />
+    <file src="/home/runner/work/Smdn.TPSmartHomeDevices/Smdn.TPSmartHomeDevices/src/Smdn.TPSmartHomeDevices.MacAddressEndPoint/bin/Release/README.md" target="README.md" />
+  </files>
 </package>
\ No newline at end of file
```

