### PR TITLE
Release main/Smdn.TPSmartHomeDevices.Kasa-1.0.1

### DIFF
--- a/doc/api-list/Smdn.TPSmartHomeDevices.Kasa/Smdn.TPSmartHomeDevices.Kasa-net6.0.apilist.cs
+++ b/doc/api-list/Smdn.TPSmartHomeDevices.Kasa/Smdn.TPSmartHomeDevices.Kasa-net6.0.apilist.cs
@@ -1,7 +1,7 @@
-// Smdn.TPSmartHomeDevices.Kasa.dll (Smdn.TPSmartHomeDevices.Kasa-1.0.0)
+// Smdn.TPSmartHomeDevices.Kasa.dll (Smdn.TPSmartHomeDevices.Kasa-1.0.1)
 //   Name: Smdn.TPSmartHomeDevices.Kasa
-//   AssemblyVersion: 1.0.0.0
-//   InformationalVersion: 1.0.0+4dd7eda1e01a411bacbd6593ca050a45b3c57c37
+//   AssemblyVersion: 1.0.1.0
+//   InformationalVersion: 1.0.1+26b3994b9e663ddd0b4c39b0a86948a876d03dad
 //   TargetFramework: .NETCoreApp,Version=v6.0
 //   Configuration: Release
 //   Referenced assemblies:

--- a/doc/api-list/Smdn.TPSmartHomeDevices.Kasa/Smdn.TPSmartHomeDevices.Kasa-net7.0.apilist.cs
+++ b/doc/api-list/Smdn.TPSmartHomeDevices.Kasa/Smdn.TPSmartHomeDevices.Kasa-net7.0.apilist.cs
@@ -1,7 +1,7 @@
-// Smdn.TPSmartHomeDevices.Kasa.dll (Smdn.TPSmartHomeDevices.Kasa-1.0.0)
+// Smdn.TPSmartHomeDevices.Kasa.dll (Smdn.TPSmartHomeDevices.Kasa-1.0.1)
 //   Name: Smdn.TPSmartHomeDevices.Kasa
-//   AssemblyVersion: 1.0.0.0
-//   InformationalVersion: 1.0.0+4dd7eda1e01a411bacbd6593ca050a45b3c57c37
+//   AssemblyVersion: 1.0.1.0
+//   InformationalVersion: 1.0.1+26b3994b9e663ddd0b4c39b0a86948a876d03dad
 //   TargetFramework: .NETCoreApp,Version=v7.0
 //   Configuration: Release
 //   Referenced assemblies:

--- a/doc/api-list/Smdn.TPSmartHomeDevices.Kasa/Smdn.TPSmartHomeDevices.Kasa-netstandard2.1.apilist.cs
+++ b/doc/api-list/Smdn.TPSmartHomeDevices.Kasa/Smdn.TPSmartHomeDevices.Kasa-netstandard2.1.apilist.cs
@@ -1,7 +1,7 @@
-// Smdn.TPSmartHomeDevices.Kasa.dll (Smdn.TPSmartHomeDevices.Kasa-1.0.0)
+// Smdn.TPSmartHomeDevices.Kasa.dll (Smdn.TPSmartHomeDevices.Kasa-1.0.1)
 //   Name: Smdn.TPSmartHomeDevices.Kasa
-//   AssemblyVersion: 1.0.0.0
-//   InformationalVersion: 1.0.0+4dd7eda1e01a411bacbd6593ca050a45b3c57c37
+//   AssemblyVersion: 1.0.1.0
+//   InformationalVersion: 1.0.1+26b3994b9e663ddd0b4c39b0a86948a876d03dad
 //   TargetFramework: .NETStandard,Version=v2.1
 //   Configuration: Release
 //   Referenced assemblies:


### PR DESCRIPTION
Automatically generated by workflow [Generate release target #17](https://github.com/smdn/Smdn.TPSmartHomeDevices/actions/runs/4972382675).

# Release target
- package_target_tag: `new-release/main/Smdn.TPSmartHomeDevices.Kasa-1.0.1`
- package_prevver_ref: `releases/Smdn.TPSmartHomeDevices.Kasa-1.0.0`
- package_prevver_tag: `releases/Smdn.TPSmartHomeDevices.Kasa-1.0.0`
- package_id: `Smdn.TPSmartHomeDevices.Kasa`
- package_id_with_version: `Smdn.TPSmartHomeDevices.Kasa-1.0.1`
- package_version: `1.0.1`
- package_branch: `main`
- release_working_branch: `releases/Smdn.TPSmartHomeDevices.Kasa-1.0.1-1684067628`
- release_tag: `releases/Smdn.TPSmartHomeDevices.Kasa-1.0.1`
- release_prerelease: `False` ❗Change this value to `true` to publish release note as a prerelease.
- release_draft: `false` ❗Change this value to `true` to publish release note as a draft.
- release_note_url: [`https://gist.github.com/smdn/b4710147b991f87dde885c73df294181`](https://gist.github.com/smdn/b4710147b991f87dde885c73df294181)
- artifact_name_nupkg: `Smdn.TPSmartHomeDevices.Kasa.1.0.1.nupkg` ❗Remove this line or change this value to empty to prevent publishing packages.

# .nuspec diff
```diff
--- Smdn.TPSmartHomeDevices.Kasa.latest.nuspec
+++ Smdn.TPSmartHomeDevices.Kasa.1.0.1.nuspec
@@ -1,33 +1,44 @@
 <?xml version="1.0" encoding="utf-8"?>
-<package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
+<package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
   <metadata>
     <id>Smdn.TPSmartHomeDevices.Kasa</id>
-    <version>1.0.0</version>
+    <version>1.0.1</version>
     <title>Smdn.TPSmartHomeDevices.Kasa</title>
     <authors>smdn</authors>
     <license type="expression">MIT</license>
     <licenseUrl>https://licenses.nuget.org/MIT</licenseUrl>
     <icon>Smdn.TPSmartHomeDevices.Kasa.png</icon>
     <readme>README.md</readme>
     <projectUrl>https://github.com/smdn/Smdn.TPSmartHomeDevices/</projectUrl>
     <description>Provides APIs for operating Kasa devices, the TP-Link smart home devices.</description>
-    <releaseNotes>https://github.com/smdn/Smdn.TPSmartHomeDevices/releases/tag/releases%2FSmdn.TPSmartHomeDevices.Kasa-1.0.0</releaseNotes>
+    <releaseNotes>https://github.com/smdn/Smdn.TPSmartHomeDevices/releases/tag/releases%2FSmdn.TPSmartHomeDevices.Kasa-1.0.1</releaseNotes>
     <copyright>Copyright © 2023 smdn</copyright>
     <tags>smdn.jp tplink-kasa,kasa,HS105,KL130,smarthome,homeautomation,smartdevice</tags>
-    <repository type="git" url="https://github.com/smdn/Smdn.TPSmartHomeDevices" branch="main" commit="4dd7eda1e01a411bacbd6593ca050a45b3c57c37" />
+    <repository type="git" url="https://github.com/smdn/Smdn.TPSmartHomeDevices" commit="26b3994b9e663ddd0b4c39b0a86948a876d03dad" />
     <dependencies>
       <group targetFramework="net6.0">
         <dependency id="Microsoft.Extensions.Logging.Abstractions" version="6.0.0" exclude="Build,Analyzers" />
         <dependency id="Smdn.TPSmartHomeDevices.Primitives" version="[1.0.0, 2.0.0)" exclude="Build,Analyzers" />
       </group>
       <group targetFramework="net7.0">
         <dependency id="Microsoft.Extensions.Logging.Abstractions" version="6.0.0" exclude="Build,Analyzers" />
         <dependency id="Smdn.TPSmartHomeDevices.Primitives" version="[1.0.0, 2.0.0)" exclude="Build,Analyzers" />
       </group>
       <group targetFramework=".NETStandard2.1">
         <dependency id="Microsoft.Extensions.Logging.Abstractions" version="6.0.0" exclude="Build,Analyzers" />
         <dependency id="Smdn.TPSmartHomeDevices.Primitives" version="[1.0.0, 2.0.0)" exclude="Build,Analyzers" />
       </group>
     </dependencies>
   </metadata>
+  <files>
+    <file src="/home/runner/work/Smdn.TPSmartHomeDevices/Smdn.TPSmartHomeDevices/src/Smdn.TPSmartHomeDevices.Kasa/bin/Release/net6.0/Smdn.TPSmartHomeDevices.Kasa.dll" target="lib/net6.0/Smdn.TPSmartHomeDevices.Kasa.dll" />
+    <file src="/home/runner/work/Smdn.TPSmartHomeDevices/Smdn.TPSmartHomeDevices/src/Smdn.TPSmartHomeDevices.Kasa/bin/Release/net6.0/Smdn.TPSmartHomeDevices.Kasa.xml" target="lib/net6.0/Smdn.TPSmartHomeDevices.Kasa.xml" />
+    <file src="/home/runner/work/Smdn.TPSmartHomeDevices/Smdn.TPSmartHomeDevices/src/Smdn.TPSmartHomeDevices.Kasa/bin/Release/net7.0/Smdn.TPSmartHomeDevices.Kasa.dll" target="lib/net7.0/Smdn.TPSmartHomeDevices.Kasa.dll" />
+    <file src="/home/runner/work/Smdn.TPSmartHomeDevices/Smdn.TPSmartHomeDevices/src/Smdn.TPSmartHomeDevices.Kasa/bin/Release/net7.0/Smdn.TPSmartHomeDevices.Kasa.xml" target="lib/net7.0/Smdn.TPSmartHomeDevices.Kasa.xml" />
+    <file src="/home/runner/work/Smdn.TPSmartHomeDevices/Smdn.TPSmartHomeDevices/src/Smdn.TPSmartHomeDevices.Kasa/bin/Release/netstandard2.1/Smdn.TPSmartHomeDevices.Kasa.dll" target="lib/netstandard2.1/Smdn.TPSmartHomeDevices.Kasa.dll" />
+    <file src="/home/runner/work/Smdn.TPSmartHomeDevices/Smdn.TPSmartHomeDevices/src/Smdn.TPSmartHomeDevices.Kasa/bin/Release/netstandard2.1/Smdn.TPSmartHomeDevices.Kasa.xml" target="lib/netstandard2.1/Smdn.TPSmartHomeDevices.Kasa.xml" />
+    <file src="/home/runner/work/Smdn.TPSmartHomeDevices/Smdn.TPSmartHomeDevices/.nuget/packages/smdn.msbuild.projectassets.common/1.3.6/project/images/package-icon.png" target="Smdn.TPSmartHomeDevices.Kasa.png" />
+    <file src="/home/runner/work/Smdn.TPSmartHomeDevices/Smdn.TPSmartHomeDevices/ThirdPartyNotices.md" target="ThirdPartyNotices.md" />
+    <file src="/home/runner/work/Smdn.TPSmartHomeDevices/Smdn.TPSmartHomeDevices/src/Smdn.TPSmartHomeDevices.Kasa/bin/Release/README.md" target="README.md" />
+  </files>
 </package>
\ No newline at end of file
```

