### PR TITLE
Add support for Tapo P110M

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ The following devices and functions are currently supported.
   - Get device informations (Tapo)
   - Get light color/brightness
   - Get on/off stete
+  - Get monitoring data (power consumption and cumulative energy usage) [Tapo P110M]
 
 ### Library features
 - Specifying devices by MAC address - [example](./examples/Smdn.TPSmartHomeDevices.MacAddressEndPoint/MacAddressResolution/), see also: [Smdn.TPSmartHomeDevices.MacAddressEndPoint](#smdntpsmarthomedevicesmacaddressendpoint)

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ The following devices and functions are currently supported.
   - L530 multicolor bulb - [example](./examples/Smdn.TPSmartHomeDevices.Tapo/L530MulticolorBulb/)
   - L900 multicolor light strip - [example](./examples/Smdn.TPSmartHomeDevices.Tapo/L900MulticolorLightStrip/)
   - P105 smart plug - [example](./examples/Smdn.TPSmartHomeDevices.Tapo/P105Plug/)
+  - P110M smart plug - [example](./examples/Smdn.TPSmartHomeDevices.Tapo/P110MPlug/)
   - Supports default (`securePassthrough`) and new (`KLAP`) protocol - [example](./examples/Smdn.TPSmartHomeDevices.Tapo/SelectProtocol/)
 - Kasa devices (as of version 1.0.0)
   - HS105 smart plug - [example](./examples/Smdn.TPSmartHomeDevices.Kasa/HS105Plug/)

--- a/examples/Smdn.TPSmartHomeDevices.Tapo/P110MPlug/Program.cs
+++ b/examples/Smdn.TPSmartHomeDevices.Tapo/P110MPlug/Program.cs
@@ -1,0 +1,28 @@
+﻿// SPDX-FileCopyrightText: 2024 smdn <smdn@smdn.jp>
+// SPDX-License-Identifier: MIT
+using System.Net;
+using Smdn.TPSmartHomeDevices.Tapo;
+
+using var plug = new P110M(IPAddress.Parse("192.0.2.255"), "user@mail.test", "password");
+
+await plug.TurnOnAsync();
+
+Console.WriteLine("Is on? {0}", await plug.GetOnOffStateAsync());
+
+var report = await plug.GetMonitoringDataAsync();
+
+Console.WriteLine($"Operating time (today): {report.TotalOperatingTimeToday?.TotalHours:N1} [hour]");
+Console.WriteLine($"Operating time (this month): {report.TotalOperatingTimeThisMonth?.TotalHours:N1} [hour]");
+
+Console.WriteLine($"Cumulative energy usage (today): {report.CumulativeEnergyUsageToday:N1} [Wh]");
+Console.WriteLine($"Cumulative energy usage (this month): {report.CumulativeEnergyUsageThisMonth:N1} [Wh]");
+
+Console.WriteLine($"Current power consumption: {report.CurrentPowerConsumption:N1} [W]");
+
+while (true) {
+  await Task.Delay(TimeSpan.FromSeconds(5));
+
+  var powerConsumption = await plug.GetCurrentPowerConsumptionAsync();
+
+  Console.WriteLine($"Current power consumption: {powerConsumption:N1} [W]");
+}

--- a/examples/Smdn.TPSmartHomeDevices.Tapo/P110MPlug/Program.csproj
+++ b/examples/Smdn.TPSmartHomeDevices.Tapo/P110MPlug/Program.csproj
@@ -1,0 +1,18 @@
+<!--
+SPDX-FileCopyrightText: 2024 smdn <smdn@smdn.jp>
+SPDX-License-Identifier: MIT
+-->
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Smdn.TPSmartHomeDevices.Tapo" Version="2.0.0" />
+  </ItemGroup>
+
+</Project>

--- a/src/Smdn.TPSmartHomeDevices.Tapo/Smdn.TPSmartHomeDevices.Tapo.Json/TapoElectricPowerInMilliWattJsonConverter.cs
+++ b/src/Smdn.TPSmartHomeDevices.Tapo/Smdn.TPSmartHomeDevices.Tapo.Json/TapoElectricPowerInMilliWattJsonConverter.cs
@@ -1,0 +1,7 @@
+// SPDX-FileCopyrightText: 2024 smdn <smdn@smdn.jp>
+// SPDX-License-Identifier: MIT
+namespace Smdn.TPSmartHomeDevices.Tapo.Json;
+
+public sealed class TapoElectricPowerInMilliWattJsonConverter : TapoElectricPowerJsonConverter {
+  private protected override decimal ToElectricPower(int value) => value * 0.001m;
+}

--- a/src/Smdn.TPSmartHomeDevices.Tapo/Smdn.TPSmartHomeDevices.Tapo.Json/TapoElectricPowerInWattJsonConverter.cs
+++ b/src/Smdn.TPSmartHomeDevices.Tapo/Smdn.TPSmartHomeDevices.Tapo.Json/TapoElectricPowerInWattJsonConverter.cs
@@ -1,0 +1,7 @@
+// SPDX-FileCopyrightText: 2024 smdn <smdn@smdn.jp>
+// SPDX-License-Identifier: MIT
+namespace Smdn.TPSmartHomeDevices.Tapo.Json;
+
+public sealed class TapoElectricPowerInWattJsonConverter : TapoElectricPowerJsonConverter {
+  private protected override decimal ToElectricPower(int value) => value;
+}

--- a/src/Smdn.TPSmartHomeDevices.Tapo/Smdn.TPSmartHomeDevices.Tapo.Json/TapoElectricPowerJsonConverter.cs
+++ b/src/Smdn.TPSmartHomeDevices.Tapo/Smdn.TPSmartHomeDevices.Tapo.Json/TapoElectricPowerJsonConverter.cs
@@ -1,0 +1,27 @@
+// SPDX-FileCopyrightText: 2024 smdn <smdn@smdn.jp>
+// SPDX-License-Identifier: MIT
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Smdn.TPSmartHomeDevices.Tapo.Json;
+
+public abstract class TapoElectricPowerJsonConverter : JsonConverter<decimal?> {
+  private protected abstract decimal ToElectricPower(int value);
+
+  public override decimal? Read(
+    ref Utf8JsonReader reader,
+    Type typeToConvert,
+    JsonSerializerOptions options
+  )
+    => reader.TokenType == JsonTokenType.Number && reader.TryGetInt32(out var value)
+      ? ToElectricPower(value)
+      : null;
+
+  public override void Write(
+    Utf8JsonWriter writer,
+    decimal? value,
+    JsonSerializerOptions options
+  )
+    => throw new NotImplementedException();
+}

--- a/src/Smdn.TPSmartHomeDevices.Tapo/Smdn.TPSmartHomeDevices.Tapo.Json/TapoLocalDateAndTimeJsonConverter.cs
+++ b/src/Smdn.TPSmartHomeDevices.Tapo/Smdn.TPSmartHomeDevices.Tapo.Json/TapoLocalDateAndTimeJsonConverter.cs
@@ -1,0 +1,36 @@
+// SPDX-FileCopyrightText: 2024 smdn <smdn@smdn.jp>
+// SPDX-License-Identifier: MIT
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Smdn.TPSmartHomeDevices.Tapo.Json;
+
+public sealed class TapoLocalDateAndTimeJsonConverter : JsonConverter<DateTime?> {
+  private const string DateAndTimeFormat = "yyyy-MM-dd HH:mm:ss";
+
+  public override DateTime? Read(
+    ref Utf8JsonReader reader,
+    Type typeToConvert,
+    JsonSerializerOptions options
+  )
+  {
+    var value = reader.TokenType == JsonTokenType.String
+      ? reader.GetString()
+      : null;
+
+    if (value is null)
+      return null;
+
+    return DateTime.TryParseExact(value, format: DateAndTimeFormat, provider: null, style: default, out var localDateAndTime)
+      ? localDateAndTime
+      : null;
+  }
+
+  public override void Write(
+    Utf8JsonWriter writer,
+    DateTime? value,
+    JsonSerializerOptions options
+  )
+    => throw new NotImplementedException();
+}

--- a/src/Smdn.TPSmartHomeDevices.Tapo/Smdn.TPSmartHomeDevices.Tapo.Protocol/GetCurrentPowerRequest.cs
+++ b/src/Smdn.TPSmartHomeDevices.Tapo/Smdn.TPSmartHomeDevices.Tapo.Protocol/GetCurrentPowerRequest.cs
@@ -1,5 +1,5 @@
 // SPDX-FileCopyrightText: 2024 smdn <smdn@smdn.jp>
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: GPL-3.0-or-later
 using System.Text.Json.Serialization;
 
 namespace Smdn.TPSmartHomeDevices.Tapo.Protocol;
@@ -7,6 +7,12 @@ namespace Smdn.TPSmartHomeDevices.Tapo.Protocol;
 /// <summary>
 /// The type that reflects <c>get_current_power</c> JSON request.
 /// </summary>
+/// <remarks>
+/// This implementation is based on and ported from the following
+/// Python implementation by <see href="https://github.com/petretiandrea">petretiandrea</see>:
+/// <see href="https://github.com/petretiandrea/plugp100">petretiandrea/plugp100</see>, published under the GPL-3.0 license,
+/// forked from <see href="https://github.com/K4CZP3R/tapo-p100-python">K4CZP3R/tapo-p100-python</see>.
+/// </remarks>
 public readonly struct GetCurrentPowerRequest : ITapoPassThroughRequest {
   [JsonPropertyName("method")]
   [JsonPropertyOrder(0)]

--- a/src/Smdn.TPSmartHomeDevices.Tapo/Smdn.TPSmartHomeDevices.Tapo.Protocol/GetCurrentPowerRequest.cs
+++ b/src/Smdn.TPSmartHomeDevices.Tapo/Smdn.TPSmartHomeDevices.Tapo.Protocol/GetCurrentPowerRequest.cs
@@ -1,0 +1,19 @@
+// SPDX-FileCopyrightText: 2024 smdn <smdn@smdn.jp>
+// SPDX-License-Identifier: MIT
+using System.Text.Json.Serialization;
+
+namespace Smdn.TPSmartHomeDevices.Tapo.Protocol;
+
+/// <summary>
+/// The type that reflects <c>get_current_power</c> JSON request.
+/// </summary>
+public readonly struct GetCurrentPowerRequest : ITapoPassThroughRequest {
+  [JsonPropertyName("method")]
+  [JsonPropertyOrder(0)]
+  public string Method => "get_current_power";
+
+#pragma warning disable CA1822
+  [JsonPropertyName("requestTimeMils")]
+  public long RequestTimeMilliseconds => 0L; // DateTimeOffset.Now.ToUnixTimeMilliseconds();
+#pragma warning restore CA1822
+}

--- a/src/Smdn.TPSmartHomeDevices.Tapo/Smdn.TPSmartHomeDevices.Tapo.Protocol/GetCurrentPowerResponse.cs
+++ b/src/Smdn.TPSmartHomeDevices.Tapo/Smdn.TPSmartHomeDevices.Tapo.Protocol/GetCurrentPowerResponse.cs
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: 2024 smdn <smdn@smdn.jp>
+// SPDX-License-Identifier: MIT
+using System.Text.Json.Serialization;
+
+namespace Smdn.TPSmartHomeDevices.Tapo.Protocol;
+
+/// <summary>
+/// The type that reflects <c>get_current_power</c> JSON response.
+/// </summary>
+/// <typeparam name="TResult">A type that will be deserialized from the value of the <c>result</c> JSON property.</typeparam>
+public readonly struct GetCurrentPowerResponse<TResult> : ITapoPassThroughResponse {
+  [JsonPropertyName("error_code")]
+  public int ErrorCode { get; init; }
+
+  [JsonPropertyName("result")]
+  public TResult Result { get; init; }
+}

--- a/src/Smdn.TPSmartHomeDevices.Tapo/Smdn.TPSmartHomeDevices.Tapo.Protocol/GetEnergyUsageRequest.cs
+++ b/src/Smdn.TPSmartHomeDevices.Tapo/Smdn.TPSmartHomeDevices.Tapo.Protocol/GetEnergyUsageRequest.cs
@@ -1,0 +1,19 @@
+// SPDX-FileCopyrightText: 2024 smdn <smdn@smdn.jp>
+// SPDX-License-Identifier: MIT
+using System.Text.Json.Serialization;
+
+namespace Smdn.TPSmartHomeDevices.Tapo.Protocol;
+
+/// <summary>
+/// The type that reflects <c>get_energy_usage</c> JSON request.
+/// </summary>
+public readonly struct GetEnergyUsageRequest : ITapoPassThroughRequest {
+  [JsonPropertyName("method")]
+  [JsonPropertyOrder(0)]
+  public string Method => "get_energy_usage";
+
+#pragma warning disable CA1822
+  [JsonPropertyName("requestTimeMils")]
+  public long RequestTimeMilliseconds => 0L; // DateTimeOffset.Now.ToUnixTimeMilliseconds();
+#pragma warning restore CA1822
+}

--- a/src/Smdn.TPSmartHomeDevices.Tapo/Smdn.TPSmartHomeDevices.Tapo.Protocol/GetEnergyUsageRequest.cs
+++ b/src/Smdn.TPSmartHomeDevices.Tapo/Smdn.TPSmartHomeDevices.Tapo.Protocol/GetEnergyUsageRequest.cs
@@ -1,5 +1,5 @@
 // SPDX-FileCopyrightText: 2024 smdn <smdn@smdn.jp>
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: GPL-3.0-or-later
 using System.Text.Json.Serialization;
 
 namespace Smdn.TPSmartHomeDevices.Tapo.Protocol;
@@ -7,6 +7,12 @@ namespace Smdn.TPSmartHomeDevices.Tapo.Protocol;
 /// <summary>
 /// The type that reflects <c>get_energy_usage</c> JSON request.
 /// </summary>
+/// <remarks>
+/// This implementation is based on and ported from the following
+/// Python implementation by <see href="https://github.com/petretiandrea">petretiandrea</see>:
+/// <see href="https://github.com/petretiandrea/plugp100">petretiandrea/plugp100</see>, published under the GPL-3.0 license,
+/// forked from <see href="https://github.com/K4CZP3R/tapo-p100-python">K4CZP3R/tapo-p100-python</see>.
+/// </remarks>
 public readonly struct GetEnergyUsageRequest : ITapoPassThroughRequest {
   [JsonPropertyName("method")]
   [JsonPropertyOrder(0)]

--- a/src/Smdn.TPSmartHomeDevices.Tapo/Smdn.TPSmartHomeDevices.Tapo.Protocol/GetEnergyUsageResponse.cs
+++ b/src/Smdn.TPSmartHomeDevices.Tapo/Smdn.TPSmartHomeDevices.Tapo.Protocol/GetEnergyUsageResponse.cs
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: 2024 smdn <smdn@smdn.jp>
+// SPDX-License-Identifier: MIT
+using System.Text.Json.Serialization;
+
+namespace Smdn.TPSmartHomeDevices.Tapo.Protocol;
+
+/// <summary>
+/// The type that reflects <c>get_energy_usage</c> JSON response.
+/// </summary>
+/// <typeparam name="TResult">A type that will be deserialized from the value of the <c>result</c> JSON property.</typeparam>
+public readonly struct GetEnergyUsageResponse<TResult> : ITapoPassThroughResponse {
+  [JsonPropertyName("error_code")]
+  public int ErrorCode { get; init; }
+
+  [JsonPropertyName("result")]
+  public TResult Result { get; init; }
+}

--- a/src/Smdn.TPSmartHomeDevices.Tapo/Smdn.TPSmartHomeDevices.Tapo.csproj
+++ b/src/Smdn.TPSmartHomeDevices.Tapo/Smdn.TPSmartHomeDevices.Tapo.csproj
@@ -30,7 +30,7 @@ SPDX-License-Identifier: MIT
 
   <PropertyGroup Label="package properties">
     <PackageLicenseExpression>GPL-3.0-or-later</PackageLicenseExpression>
-    <PackageTags>tplink-tapo,tapo,L530,L900,P105,$(PackageCommonTags)</PackageTags>
+    <PackageTags>tplink-tapo,tapo,L530,L900,P105,P110M,$(PackageCommonTags)</PackageTags>
     <GenerateNupkgReadmeFileDependsOnTargets>$(GenerateNupkgReadmeFileDependsOnTargets);GenerateReadmeFileContent</GenerateNupkgReadmeFileDependsOnTargets>
   </PropertyGroup>
 

--- a/src/Smdn.TPSmartHomeDevices.Tapo/Smdn.TPSmartHomeDevices.Tapo/P110M.cs
+++ b/src/Smdn.TPSmartHomeDevices.Tapo/Smdn.TPSmartHomeDevices.Tapo/P110M.cs
@@ -186,4 +186,23 @@ public class P110M : TapoDevice {
       composeResult: static result => result.Result.CurrentPower,
       cancellationToken: cancellationToken
     );
+
+  /// <summary>
+  /// Gets the monitoring data report for the device connected to <see cref="P110M"/>.
+  /// </summary>
+  /// <returns>
+  /// A <see cref="ValueTask{TResult}"/> representing the result of method.
+  /// </returns>
+  public virtual ValueTask<TapoPlugMonitoringData> GetMonitoringDataAsync(
+    CancellationToken cancellationToken = default
+  )
+    => SendRequestAsync<
+      GetEnergyUsageRequest,
+      GetEnergyUsageResponse<TapoPlugMonitoringData>,
+      TapoPlugMonitoringData
+    >(
+      request: default,
+      composeResult: static result => result.Result,
+      cancellationToken: cancellationToken
+    );
 }

--- a/src/Smdn.TPSmartHomeDevices.Tapo/Smdn.TPSmartHomeDevices.Tapo/P110M.cs
+++ b/src/Smdn.TPSmartHomeDevices.Tapo/Smdn.TPSmartHomeDevices.Tapo/P110M.cs
@@ -1,0 +1,157 @@
+// SPDX-FileCopyrightText: 2024 smdn <smdn@smdn.jp>
+// SPDX-License-Identifier: MIT
+using System;
+using System.Net;
+using System.Net.NetworkInformation;
+
+using Smdn.TPSmartHomeDevices.Tapo.Credentials;
+
+namespace Smdn.TPSmartHomeDevices.Tapo;
+
+/// <summary>
+/// Provides APIs to operate Tapo P110M, Mini Smart Wi-Fi Plug, Energy Monitoring.
+/// </summary>
+/// <remarks>
+/// This is an unofficial API that has no affiliation with TP-Link.
+/// This API is released under the <see href="https://opensource.org/license/mit/">MIT License</see>, and as stated in the terms of the MIT License,
+/// there is no warranty for the results of using this API and no responsibility is taken for those results.
+/// </remarks>
+/// <seealso href="https://www.tp-link.com/jp/smart-home/tapo/tapo-p110m/">Tapo P110M product information (ja)</seealso>
+public class P110M : TapoDevice {
+  /// <summary>
+  /// Initializes a new instance of the <see cref="P110M"/> class with specifying the device endpoint by host name.
+  /// </summary>
+  /// <inheritdoc cref="TapoDevice(string, string, string, IServiceProvider?)" />
+  public P110M(
+    string host,
+    string email,
+    string password,
+    IServiceProvider? serviceProvider = null
+  )
+    : base(
+      host: host,
+      email: email,
+      password: password,
+      serviceProvider: serviceProvider
+    )
+  {
+  }
+
+  /// <summary>
+  /// Initializes a new instance of the <see cref="P110M"/> class with specifying the device endpoint by host name.
+  /// </summary>
+  /// <inheritdoc cref="TapoDevice(string, IServiceProvider)" />
+  public P110M(
+    string host,
+    IServiceProvider serviceProvider
+  )
+    : base(
+      host: host,
+      serviceProvider: serviceProvider
+    )
+  {
+  }
+
+  /// <summary>
+  /// Initializes a new instance of the <see cref="P110M"/> class with specifying the device endpoint by IP address.
+  /// </summary>
+  /// <inheritdoc cref="TapoDevice(string, string, string, IServiceProvider?)" />
+  public P110M(
+    IPAddress ipAddress,
+    string email,
+    string password,
+    IServiceProvider? serviceProvider = null
+  )
+    : base(
+      ipAddress: ipAddress,
+      email: email,
+      password: password,
+      serviceProvider: serviceProvider
+    )
+  {
+  }
+
+  /// <summary>
+  /// Initializes a new instance of the <see cref="P110M"/> class with specifying the device endpoint by IP address.
+  /// </summary>
+  /// <inheritdoc cref="TapoDevice(IPAddress, IServiceProvider)" />
+  public P110M(
+    IPAddress ipAddress,
+    IServiceProvider serviceProvider
+  )
+    : base(
+      ipAddress: ipAddress,
+      serviceProvider: serviceProvider
+    )
+  {
+  }
+
+  /// <summary>
+  /// Initializes a new instance of the <see cref="P110M"/> class with specifying the device endpoint by MAC address.
+  /// </summary>
+  /// <inheritdoc cref="TapoDevice(PhysicalAddress, string, string, IServiceProvider?)" />
+  public P110M(
+    PhysicalAddress macAddress,
+    string email,
+    string password,
+    IServiceProvider serviceProvider
+  )
+    : base(
+      macAddress: macAddress,
+      email: email,
+      password: password,
+      serviceProvider: serviceProvider
+    )
+  {
+  }
+
+  /// <summary>
+  /// Initializes a new instance of the <see cref="P110M"/> class with specifying the device endpoint by MAC address.
+  /// </summary>
+  /// <inheritdoc cref="TapoDevice(PhysicalAddress, IServiceProvider)" />
+  public P110M(
+    PhysicalAddress macAddress,
+    IServiceProvider serviceProvider
+  )
+    : base(
+      macAddress: macAddress,
+      serviceProvider: serviceProvider
+    )
+  {
+  }
+
+  /// <summary>
+  /// Initializes a new instance of the <see cref="P110M"/> class.
+  /// </summary>
+  /// <inheritdoc
+  ///   cref="TapoDevice(IDeviceEndPoint, ITapoCredentialProvider?, TapoDeviceExceptionHandler?, IServiceProvider?)"
+  ///   path="/exception | /param[@name='deviceEndPoint' or @name='credential' or @name='serviceProvider']"
+  /// />
+  public P110M(
+    IDeviceEndPoint deviceEndPoint,
+    ITapoCredentialProvider? credential = null,
+    IServiceProvider? serviceProvider = null
+  )
+    : base(
+      deviceEndPoint: deviceEndPoint,
+      credential: credential,
+      serviceProvider: serviceProvider
+    )
+  {
+  }
+
+  /// <inheritdoc cref="TapoDevice.Create{TAddress}(TAddress, IServiceProvider, ITapoCredentialProvider?)" />
+  public static new P110M Create<TAddress>(
+    TAddress deviceAddress,
+    IServiceProvider serviceProvider,
+    ITapoCredentialProvider? credential = null
+  ) where TAddress : notnull
+    => new(
+      deviceEndPoint: DeviceEndPoint.Create(
+        address: deviceAddress,
+        serviceProvider.GetDeviceEndPointFactory<TAddress>()
+      ),
+      credential: credential,
+      serviceProvider: serviceProvider
+    );
+}

--- a/src/Smdn.TPSmartHomeDevices.Tapo/Smdn.TPSmartHomeDevices.Tapo/P110M.cs
+++ b/src/Smdn.TPSmartHomeDevices.Tapo/Smdn.TPSmartHomeDevices.Tapo/P110M.cs
@@ -3,8 +3,13 @@
 using System;
 using System.Net;
 using System.Net.NetworkInformation;
+using System.Text.Json.Serialization;
+using System.Threading;
+using System.Threading.Tasks;
 
 using Smdn.TPSmartHomeDevices.Tapo.Credentials;
+using Smdn.TPSmartHomeDevices.Tapo.Json;
+using Smdn.TPSmartHomeDevices.Tapo.Protocol;
 
 namespace Smdn.TPSmartHomeDevices.Tapo;
 
@@ -153,5 +158,32 @@ public class P110M : TapoDevice {
       ),
       credential: credential,
       serviceProvider: serviceProvider
+    );
+
+  private readonly struct GetCurrentPowerResult {
+    [JsonPropertyName("current_power")]
+    [JsonConverter(typeof(TapoElectricPowerInWattJsonConverter))]
+    public decimal? CurrentPower { get; init; }
+  }
+
+  /// <summary>
+  /// Gets the current power consumption for the device connected to <see cref="P110M"/>.
+  /// </summary>
+  /// <returns>
+  /// A <see cref="ValueTask{TResult}"/> representing the result of method.
+  /// If the power consumption is successfully retrieved, the <see cref="decimal"/> value that represents the power consumption in unit of watt [W], is set.
+  /// If the device does not support retrieving the power consumption, the value of <see cref="ValueTask{TResult}"/> will be <see langword="null"/>.
+  /// </returns>
+  public virtual ValueTask<decimal?> GetCurrentPowerConsumptionAsync(
+    CancellationToken cancellationToken = default
+  )
+    => SendRequestAsync<
+      GetCurrentPowerRequest,
+      GetCurrentPowerResponse<GetCurrentPowerResult>,
+      decimal?
+    >(
+      request: default,
+      composeResult: static result => result.Result.CurrentPower,
+      cancellationToken: cancellationToken
     );
 }

--- a/src/Smdn.TPSmartHomeDevices.Tapo/Smdn.TPSmartHomeDevices.Tapo/TapoPlugMonitoringData.cs
+++ b/src/Smdn.TPSmartHomeDevices.Tapo/Smdn.TPSmartHomeDevices.Tapo/TapoPlugMonitoringData.cs
@@ -1,0 +1,76 @@
+// SPDX-FileCopyrightText: 2024 smdn <smdn@smdn.jp>
+// SPDX-License-Identifier: MIT
+using System;
+using System.Text.Json.Serialization;
+
+using Smdn.TPSmartHomeDevices.Json;
+using Smdn.TPSmartHomeDevices.Tapo.Json;
+
+namespace Smdn.TPSmartHomeDevices.Tapo;
+
+/// <summary>
+/// Represents the usage monitoring data report for devices connected to the Tapo smart plug.
+/// </summary>
+/// <seealso cref="P110M.GetMonitoringDataAsync(System.Threading.CancellationToken)"/>
+public class TapoPlugMonitoringData {
+  /// <summary>
+  /// Gets the <see cref="TimeSpan"/> value that represents today's total operating time.
+  /// </summary>
+  [JsonPropertyName("today_runtime")]
+  [JsonConverter(typeof(TimeSpanInMinutesJsonConverter))]
+  public TimeSpan? TotalOperatingTimeToday { get; init; }
+
+  /// <summary>
+  /// Gets the <see cref="TimeSpan"/> value that represents this month's total operating time.
+  /// </summary>
+  [JsonPropertyName("month_runtime")]
+  [JsonConverter(typeof(TimeSpanInMinutesJsonConverter))]
+  public TimeSpan? TotalOperatingTimeThisMonth { get; init; }
+
+  /// <summary>
+  /// Gets the <see cref="decimal"/> value that represents today's cumulative energy usage.
+  /// </summary>
+  /// <value>
+  /// The cumulative usage amount of electric energy, in unit of watt-hours [Wh].
+  /// <see langword="null"/> if the device does not return value for this property.
+  /// </value>
+  [JsonPropertyName("today_energy")]
+  [JsonConverter(typeof(TapoElectricEnergyInWattHourJsonConverter))]
+  public decimal? CumulativeEnergyUsageToday { get; init; }
+
+  /// <summary>
+  /// Gets the <see cref="decimal"/> value that represents this month's cumulative energy usage.
+  /// </summary>
+  /// <value>
+  /// The cumulative usage amount of electric energy, in unit of watt-hours [Wh].
+  /// <see langword="null"/> if the device does not return value for this property.
+  /// </value>
+  [JsonPropertyName("month_energy")]
+  [JsonConverter(typeof(TapoElectricEnergyInWattHourJsonConverter))]
+  public decimal? CumulativeEnergyUsageThisMonth { get; init; }
+
+  /// <summary>
+  /// Gets the <see cref="DateTime"/> that represents the date and time this monitoring data was measured.
+  /// </summary>
+  /// <value>
+  /// The local date and time in the time zone set for the device.
+  /// This property returns the <see cref="DateTime"/> for which <see cref="DateTime.Kind"/> is <see cref="DateTimeKind.Unspecified"/>.
+  /// </value>
+  [JsonPropertyName("local_time")]
+  [JsonConverter(typeof(TapoLocalDateAndTimeJsonConverter))]
+  public DateTime? TimeStamp { get; init; }
+
+  // TODO: electricity_charge
+  // [JsonPropertyName("electricity_charge")]
+  // private ElectricityCharge? ElectricityCharge { get; init; }
+
+  /// <summary>
+  /// Gets the <see cref="decimal"/> value that represents the current power consumption.
+  /// </summary>
+  /// <value>
+  /// The power consumption, in unit of watt [W].
+  /// </value>
+  [JsonPropertyName("current_power")]
+  [JsonConverter(typeof(TapoElectricPowerInMilliWattJsonConverter))]
+  public decimal? CurrentPowerConsumption { get; init; }
+}

--- a/tests/Smdn.TPSmartHomeDevices.Tapo/Smdn.TPSmartHomeDevices.Tapo/P110M.cs
+++ b/tests/Smdn.TPSmartHomeDevices.Tapo/Smdn.TPSmartHomeDevices.Tapo/P110M.cs
@@ -2,10 +2,14 @@
 // SPDX-License-Identifier: MIT
 using System;
 using System.Text;
+using System.Text.Json.Serialization;
+using System.Threading.Tasks;
 
 using Microsoft.Extensions.DependencyInjection;
 
 using NUnit.Framework;
+
+using Smdn.TPSmartHomeDevices.Tapo.Protocol;
 
 namespace Smdn.TPSmartHomeDevices.Tapo;
 
@@ -31,4 +35,39 @@ public class P110MTests {
   [TestCaseSource(typeof(ConcreteTapoDeviceCommonTests), nameof(ConcreteTapoDeviceCommonTests.YiledTestCases_Ctor_ArgumentException))]
   public void Ctor_ArgumentException(Type[] ctorParameterTypes, object?[] ctorParameters, Type? expectedExceptionType, string expectedParamName)
     => ConcreteTapoDeviceCommonTests.TestCtor_ArgumentException<P110M>(ctorParameterTypes, ctorParameters, expectedExceptionType, expectedParamName);
+
+  private readonly struct GetCurrentPowerResult(int currentPower) {
+    [JsonPropertyName("current_power")]
+    public int? CurrentPower { get; } = currentPower;
+  }
+
+  [TestCase(0, 0)]
+  [TestCase(1, 1)]
+  public async Task GetCurrentPowerConsumptionAsync(int currentPower, decimal expectedValueInWatt)
+  {
+    await using var pseudoDevice = new PseudoTapoDevice() {
+      FuncGenerateToken = static _ => "token",
+      FuncGeneratePassThroughResponse = (_, method, requestParams) => {
+        return (
+          KnownErrorCodes.Success,
+          new GetCurrentPowerResponse<GetCurrentPowerResult>() {
+            ErrorCode = KnownErrorCodes.Success,
+            Result = new(currentPower: currentPower),
+          }
+        );
+      }
+    };
+
+    pseudoDevice.Start();
+
+    using var device = new P110M(
+      deviceEndPoint: pseudoDevice.GetEndPoint(),
+      serviceProvider: services!.BuildServiceProvider()
+    );
+
+    var powerConsumption = await device.GetCurrentPowerConsumptionAsync();
+
+    Assert.That(powerConsumption, Is.Not.Null);
+    Assert.That(powerConsumption.Value, Is.EqualTo(expectedValueInWatt));
+  }
 }

--- a/tests/Smdn.TPSmartHomeDevices.Tapo/Smdn.TPSmartHomeDevices.Tapo/P110M.cs
+++ b/tests/Smdn.TPSmartHomeDevices.Tapo/Smdn.TPSmartHomeDevices.Tapo/P110M.cs
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: 2024 smdn <smdn@smdn.jp>
+// SPDX-License-Identifier: MIT
+using System;
+using System.Text;
+
+using Microsoft.Extensions.DependencyInjection;
+
+using NUnit.Framework;
+
+namespace Smdn.TPSmartHomeDevices.Tapo;
+
+[TestFixture]
+public class P110MTests {
+  private ServiceCollection? services;
+
+  [OneTimeSetUp]
+  public void SetUp()
+  {
+    services = new ServiceCollection();
+
+    services.AddTapoBase64EncodedCredential(
+      base64UserNameSHA1Digest: Convert.ToBase64String(Encoding.UTF8.GetBytes("user")),
+      base64Password: Convert.ToBase64String(Encoding.UTF8.GetBytes("pass"))
+    );
+  }
+
+  [Test]
+  public new void ToString()
+    => ConcreteTapoDeviceCommonTests.TestToString<P110M>();
+
+  [TestCaseSource(typeof(ConcreteTapoDeviceCommonTests), nameof(ConcreteTapoDeviceCommonTests.YiledTestCases_Ctor_ArgumentException))]
+  public void Ctor_ArgumentException(Type[] ctorParameterTypes, object?[] ctorParameters, Type? expectedExceptionType, string expectedParamName)
+    => ConcreteTapoDeviceCommonTests.TestCtor_ArgumentException<P110M>(ctorParameterTypes, ctorParameters, expectedExceptionType, expectedParamName);
+}


### PR DESCRIPTION
<!-- Please fill the following template according to what changes this pull request will make. -->
<!-- 以下はテンプレートです。　Pull Requestの内容に合わせて記入してください。 -->
<!-- 英語での記入が望ましいですが、日本語でも構いません。 -->

### Description
This PR adds support for 'Tapo P110M, Mini Smart Wi-Fi Plug, Energy Monitoring'.

The implementations of the requests `get_current_power` and `get_energy_usage` included in this PR are based on and ported from the following implementation: [petretiandrea/plugp100](https://github.com/petretiandrea/plugp100), published under the GPL-3.0 license.

### Testing
<!-- Describe what kind of verification and testing you have performed related to this change. -->
<!-- この変更に関連して、どのようなテストや検証を行ったかを記入してください。 -->
This PR tested with .NET 8 on Ubuntu 22.04, using with actual Tapo P110M device.
