### PR TITLE
Release main/Smdn.TPSmartHomeDevices.Primitives-1.1.0-preview2

### DIFF
--- a/doc/api-list/Smdn.TPSmartHomeDevices.Primitives/Smdn.TPSmartHomeDevices.Primitives-net8.0.apilist.cs
+++ b/doc/api-list/Smdn.TPSmartHomeDevices.Primitives/Smdn.TPSmartHomeDevices.Primitives-net8.0.apilist.cs
@@ -2,16 +2,16 @@
 //   Name: Smdn.TPSmartHomeDevices.Primitives
 //   AssemblyVersion: 1.1.0.0
 //   InformationalVersion: 1.1.0-preview2+e153b40ab2e10cbae4165a6013f9be14e5465b75
-//   TargetFramework: .NETCoreApp,Version=v6.0
+//   TargetFramework: .NETCoreApp,Version=v8.0
 //   Configuration: Release
 //   Referenced assemblies:
 //     Microsoft.Extensions.DependencyInjection.Abstractions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60
 //     Smdn.Fundamental.PrintableEncoding.Hexadecimal, Version=3.0.1.0, Culture=neutral
-//     System.Memory, Version=6.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51
-//     System.Net.NetworkInformation, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
-//     System.Net.Primitives, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
-//     System.Runtime, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
-//     System.Text.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51
+//     System.Memory, Version=8.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51
+//     System.Net.NetworkInformation, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
+//     System.Net.Primitives, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
+//     System.Runtime, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
+//     System.Text.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51
 #nullable enable annotations
 
 using System;

--- a/doc/api-list/Smdn.TPSmartHomeDevices.Primitives/Smdn.TPSmartHomeDevices.Primitives-netstandard2.0.apilist.cs
+++ b/doc/api-list/Smdn.TPSmartHomeDevices.Primitives/Smdn.TPSmartHomeDevices.Primitives-netstandard2.0.apilist.cs
@@ -1,11 +1,13 @@
-// Smdn.TPSmartHomeDevices.Primitives.dll (Smdn.TPSmartHomeDevices.Primitives-1.1.0-preview1)
+// Smdn.TPSmartHomeDevices.Primitives.dll (Smdn.TPSmartHomeDevices.Primitives-1.1.0-preview2)
 //   Name: Smdn.TPSmartHomeDevices.Primitives
 //   AssemblyVersion: 1.1.0.0
-//   InformationalVersion: 1.1.0-preview1+d9122eb664899e2e3470e87efca152f3456eb904
+//   InformationalVersion: 1.1.0-preview2+e153b40ab2e10cbae4165a6013f9be14e5465b75
 //   TargetFramework: .NETStandard,Version=v2.0
 //   Configuration: Release
 //   Referenced assemblies:
 //     Microsoft.Extensions.DependencyInjection.Abstractions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60
+//     Smdn.Fundamental.PrintableEncoding.Hexadecimal, Version=3.0.1.0, Culture=neutral
+//     System.Memory, Version=4.0.1.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51
 //     System.Text.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51
 //     System.Threading.Tasks.Extensions, Version=4.2.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51
 //     netstandard, Version=2.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51
@@ -31,22 +33,31 @@ namespace Smdn.TPSmartHomeDevices {
     IDeviceEndPoint Create(TAddress address);
   }
 
+  public interface IDeviceInfo {
+    string? FirmwareVersion { get; }
+    string? HardwareVersion { get; }
+    ReadOnlySpan<byte> Id { get; }
+    PhysicalAddress? MacAddress { get; }
+    string? ModelName { get; }
+  }
+
   public interface IDynamicDeviceEndPoint : IDeviceEndPoint {
     void Invalidate();
   }
 
-  public interface IMulticolorSmartLight : ISmartDevice {
-    ValueTask SetBrightnessAsync(int brightness, TimeSpan transitionPeriod, CancellationToken cancellationToken);
+  public interface IMulticolorSmartLight : ISmartLight {
     ValueTask SetColorAsync(int hue, int saturation, int? brightness, TimeSpan transitionPeriod, CancellationToken cancellationToken);
     ValueTask SetColorTemperatureAsync(int colorTemperature, int? brightness, TimeSpan transitionPeriod, CancellationToken cancellationToken);
   }
 
   public interface ISmartDevice {
+    ValueTask<IDeviceInfo> GetDeviceInfoAsync(CancellationToken cancellationToken = default);
     ValueTask<bool> GetOnOffStateAsync(CancellationToken cancellationToken);
     ValueTask SetOnOffStateAsync(bool newOnOffState, CancellationToken cancellationToken);
   }
 
-  public interface ISmartPlug : ISmartDevice {
+  public interface ISmartLight : ISmartDevice {
+    ValueTask SetBrightnessAsync(int brightness, TimeSpan transitionPeriod, CancellationToken cancellationToken);
   }
 
   public static class DeviceEndPoint {
@@ -80,6 +91,13 @@ namespace Smdn.TPSmartHomeDevices {
 }
 
 namespace Smdn.TPSmartHomeDevices.Json {
+  public sealed class Base16ByteArrayJsonConverter : JsonConverter<byte[]> {
+    public Base16ByteArrayJsonConverter() {}
+
+    public override byte[]? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) {}
+    public override void Write(Utf8JsonWriter writer, byte[]? @value, JsonSerializerOptions options) {}
+  }
+
   public sealed class GeolocationInDecimalDegreesJsonConverter : JsonConverter<decimal?> {
     public GeolocationInDecimalDegreesJsonConverter() {}
 

--- a/doc/api-list/Smdn.TPSmartHomeDevices.Primitives/Smdn.TPSmartHomeDevices.Primitives-netstandard2.1.apilist.cs
+++ b/doc/api-list/Smdn.TPSmartHomeDevices.Primitives/Smdn.TPSmartHomeDevices.Primitives-netstandard2.1.apilist.cs
@@ -1,11 +1,12 @@
-// Smdn.TPSmartHomeDevices.Primitives.dll (Smdn.TPSmartHomeDevices.Primitives-1.1.0-preview1)
+// Smdn.TPSmartHomeDevices.Primitives.dll (Smdn.TPSmartHomeDevices.Primitives-1.1.0-preview2)
 //   Name: Smdn.TPSmartHomeDevices.Primitives
 //   AssemblyVersion: 1.1.0.0
-//   InformationalVersion: 1.1.0-preview1+d9122eb664899e2e3470e87efca152f3456eb904
+//   InformationalVersion: 1.1.0-preview2+e153b40ab2e10cbae4165a6013f9be14e5465b75
 //   TargetFramework: .NETStandard,Version=v2.1
 //   Configuration: Release
 //   Referenced assemblies:
 //     Microsoft.Extensions.DependencyInjection.Abstractions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60
+//     Smdn.Fundamental.PrintableEncoding.Hexadecimal, Version=3.0.1.0, Culture=neutral
 //     System.Text.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51
 //     netstandard, Version=2.1.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51
 #nullable enable annotations
@@ -30,22 +31,31 @@ namespace Smdn.TPSmartHomeDevices {
     IDeviceEndPoint Create(TAddress address);
   }
 
+  public interface IDeviceInfo {
+    string? FirmwareVersion { get; }
+    string? HardwareVersion { get; }
+    ReadOnlySpan<byte> Id { get; }
+    PhysicalAddress? MacAddress { get; }
+    string? ModelName { get; }
+  }
+
   public interface IDynamicDeviceEndPoint : IDeviceEndPoint {
     void Invalidate();
   }
 
-  public interface IMulticolorSmartLight : ISmartDevice {
-    ValueTask SetBrightnessAsync(int brightness, TimeSpan transitionPeriod, CancellationToken cancellationToken);
+  public interface IMulticolorSmartLight : ISmartLight {
     ValueTask SetColorAsync(int hue, int saturation, int? brightness, TimeSpan transitionPeriod, CancellationToken cancellationToken);
     ValueTask SetColorTemperatureAsync(int colorTemperature, int? brightness, TimeSpan transitionPeriod, CancellationToken cancellationToken);
   }
 
   public interface ISmartDevice {
+    ValueTask<IDeviceInfo> GetDeviceInfoAsync(CancellationToken cancellationToken = default);
     ValueTask<bool> GetOnOffStateAsync(CancellationToken cancellationToken);
     ValueTask SetOnOffStateAsync(bool newOnOffState, CancellationToken cancellationToken);
   }
 
-  public interface ISmartPlug : ISmartDevice {
+  public interface ISmartLight : ISmartDevice {
+    ValueTask SetBrightnessAsync(int brightness, TimeSpan transitionPeriod, CancellationToken cancellationToken);
   }
 
   public static class DeviceEndPoint {
@@ -79,6 +89,13 @@ namespace Smdn.TPSmartHomeDevices {
 }
 
 namespace Smdn.TPSmartHomeDevices.Json {
+  public sealed class Base16ByteArrayJsonConverter : JsonConverter<byte[]> {
+    public Base16ByteArrayJsonConverter() {}
+
+    public override byte[]? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) {}
+    [...] public override <unknown> Write(...) {}
+  }
+
   public sealed class GeolocationInDecimalDegreesJsonConverter : JsonConverter<decimal?> {
     public GeolocationInDecimalDegreesJsonConverter() {}
 


### PR DESCRIPTION
Automatically generated by workflow [Generate release target #24](https://github.com/smdn/Smdn.TPSmartHomeDevices/actions/runs/7543930008).

# Release target
- package_target_tag: `new-release/main/Smdn.TPSmartHomeDevices.Primitives-1.1.0-preview2`
- package_prevver_ref: `releases/Smdn.TPSmartHomeDevices.Primitives-1.1.0-preview1`
- package_prevver_tag: `releases/Smdn.TPSmartHomeDevices.Primitives-1.1.0-preview1`
- package_id: `Smdn.TPSmartHomeDevices.Primitives`
- package_id_with_version: `Smdn.TPSmartHomeDevices.Primitives-1.1.0-preview2`
- package_version: `1.1.0-preview2`
- package_branch: `main`
- release_working_branch: `releases/Smdn.TPSmartHomeDevices.Primitives-1.1.0-preview2-1705419362`
- release_tag: `releases/Smdn.TPSmartHomeDevices.Primitives-1.1.0-preview2`
- release_prerelease: `True` ❗Change this value to `true` to publish release note as a prerelease.
- release_draft: `false` ❗Change this value to `true` to publish release note as a draft.
- release_note_url: [`https://gist.github.com/smdn/c0bacfad8de7d485c301ab2629150a0b`](https://gist.github.com/smdn/c0bacfad8de7d485c301ab2629150a0b)
- artifact_name_nupkg: `Smdn.TPSmartHomeDevices.Primitives.1.1.0-preview2.nupkg` ❗Remove this line or change this value to empty to prevent publishing packages.

# .nuspec diff
```diff
--- Smdn.TPSmartHomeDevices.Primitives.latest.nuspec
+++ Smdn.TPSmartHomeDevices.Primitives.1.1.0-preview2.nuspec
@@ -1,33 +1,53 @@
 <?xml version="1.0" encoding="utf-8"?>
-<package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
+<package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
   <metadata>
     <id>Smdn.TPSmartHomeDevices.Primitives</id>
-    <version>1.1.0-preview1</version>
+    <version>1.1.0-preview2</version>
     <title>Smdn.TPSmartHomeDevices.Primitives</title>
     <authors>smdn</authors>
     <license type="expression">MIT</license>
     <licenseUrl>https://licenses.nuget.org/MIT</licenseUrl>
     <icon>Smdn.TPSmartHomeDevices.Primitives.png</icon>
     <readme>README.md</readme>
     <projectUrl>https://github.com/smdn/Smdn.TPSmartHomeDevices/</projectUrl>
     <description>Provides common types for Smdn.TPSmartHomeDevices.Tapo and Smdn.TPSmartHomeDevices.Kasa, including abstraction interfaces, extension methods and custom JsonConverter's. This library does not provide any specific implementations to operate Kasa and Tapo devices.</description>
-    <releaseNotes>https://github.com/smdn/Smdn.TPSmartHomeDevices/releases/tag/releases%2FSmdn.TPSmartHomeDevices.Primitives-1.1.0-preview1</releaseNotes>
+    <releaseNotes>https://github.com/smdn/Smdn.TPSmartHomeDevices/releases/tag/releases%2FSmdn.TPSmartHomeDevices.Primitives-1.1.0-preview2</releaseNotes>
     <copyright>Copyright © 2023 smdn</copyright>
     <tags>smdn.jp tplink-kasa,kasa,tplink-tapo,tapo,common,smarthome,homeautomation,smartdevice</tags>
-    <repository type="git" url="https://github.com/smdn/Smdn.TPSmartHomeDevices" branch="main" commit="d9122eb664899e2e3470e87efca152f3456eb904" />
+    <repository type="git" url="https://github.com/smdn/Smdn.TPSmartHomeDevices" commit="e153b40ab2e10cbae4165a6013f9be14e5465b75" />
     <dependencies>
       <group targetFramework="net6.0">
         <dependency id="Microsoft.Extensions.DependencyInjection.Abstractions" version="6.0.0" exclude="Build,Analyzers" />
+        <dependency id="Smdn.Fundamental.PrintableEncoding.Hexadecimal" version="3.0.1" exclude="Build,Analyzers" />
+        <dependency id="System.Text.Json" version="6.0.0" exclude="Build,Analyzers" />
+      </group>
+      <group targetFramework="net8.0">
+        <dependency id="Microsoft.Extensions.DependencyInjection.Abstractions" version="6.0.0" exclude="Build,Analyzers" />
+        <dependency id="Smdn.Fundamental.PrintableEncoding.Hexadecimal" version="3.0.1" exclude="Build,Analyzers" />
         <dependency id="System.Text.Json" version="6.0.0" exclude="Build,Analyzers" />
       </group>
       <group targetFramework=".NETStandard2.0">
         <dependency id="Microsoft.Extensions.DependencyInjection.Abstractions" version="6.0.0" exclude="Build,Analyzers" />
+        <dependency id="Smdn.Fundamental.PrintableEncoding.Hexadecimal" version="3.0.1" exclude="Build,Analyzers" />
         <dependency id="System.Text.Json" version="6.0.0" exclude="Build,Analyzers" />
       </group>
       <group targetFramework=".NETStandard2.1">
         <dependency id="Microsoft.Extensions.DependencyInjection.Abstractions" version="6.0.0" exclude="Build,Analyzers" />
+        <dependency id="Smdn.Fundamental.PrintableEncoding.Hexadecimal" version="3.0.1" exclude="Build,Analyzers" />
         <dependency id="System.Text.Json" version="6.0.0" exclude="Build,Analyzers" />
       </group>
     </dependencies>
   </metadata>
+  <files>
+    <file src="/home/runner/work/Smdn.TPSmartHomeDevices/Smdn.TPSmartHomeDevices/src/Smdn.TPSmartHomeDevices.Primitives/bin/Release/net6.0/Smdn.TPSmartHomeDevices.Primitives.dll" target="lib/net6.0/Smdn.TPSmartHomeDevices.Primitives.dll" />
+    <file src="/home/runner/work/Smdn.TPSmartHomeDevices/Smdn.TPSmartHomeDevices/src/Smdn.TPSmartHomeDevices.Primitives/bin/Release/net6.0/Smdn.TPSmartHomeDevices.Primitives.xml" target="lib/net6.0/Smdn.TPSmartHomeDevices.Primitives.xml" />
+    <file src="/home/runner/work/Smdn.TPSmartHomeDevices/Smdn.TPSmartHomeDevices/src/Smdn.TPSmartHomeDevices.Primitives/bin/Release/net8.0/Smdn.TPSmartHomeDevices.Primitives.dll" target="lib/net8.0/Smdn.TPSmartHomeDevices.Primitives.dll" />
+    <file src="/home/runner/work/Smdn.TPSmartHomeDevices/Smdn.TPSmartHomeDevices/src/Smdn.TPSmartHomeDevices.Primitives/bin/Release/net8.0/Smdn.TPSmartHomeDevices.Primitives.xml" target="lib/net8.0/Smdn.TPSmartHomeDevices.Primitives.xml" />
+    <file src="/home/runner/work/Smdn.TPSmartHomeDevices/Smdn.TPSmartHomeDevices/src/Smdn.TPSmartHomeDevices.Primitives/bin/Release/netstandard2.0/Smdn.TPSmartHomeDevices.Primitives.dll" target="lib/netstandard2.0/Smdn.TPSmartHomeDevices.Primitives.dll" />
+    <file src="/home/runner/work/Smdn.TPSmartHomeDevices/Smdn.TPSmartHomeDevices/src/Smdn.TPSmartHomeDevices.Primitives/bin/Release/netstandard2.0/Smdn.TPSmartHomeDevices.Primitives.xml" target="lib/netstandard2.0/Smdn.TPSmartHomeDevices.Primitives.xml" />
+    <file src="/home/runner/work/Smdn.TPSmartHomeDevices/Smdn.TPSmartHomeDevices/src/Smdn.TPSmartHomeDevices.Primitives/bin/Release/netstandard2.1/Smdn.TPSmartHomeDevices.Primitives.dll" target="lib/netstandard2.1/Smdn.TPSmartHomeDevices.Primitives.dll" />
+    <file src="/home/runner/work/Smdn.TPSmartHomeDevices/Smdn.TPSmartHomeDevices/src/Smdn.TPSmartHomeDevices.Primitives/bin/Release/netstandard2.1/Smdn.TPSmartHomeDevices.Primitives.xml" target="lib/netstandard2.1/Smdn.TPSmartHomeDevices.Primitives.xml" />
+    <file src="/home/runner/work/Smdn.TPSmartHomeDevices/Smdn.TPSmartHomeDevices/.nuget/packages/smdn.msbuild.projectassets.common/1.4.0/project/images/package-icon.png" target="Smdn.TPSmartHomeDevices.Primitives.png" />
+    <file src="/home/runner/work/Smdn.TPSmartHomeDevices/Smdn.TPSmartHomeDevices/src/Smdn.TPSmartHomeDevices.Primitives/bin/Release/README.md" target="README.md" />
+  </files>
 </package>
\ No newline at end of file
```

