### PR TITLE
Release main/Smdn.TPSmartHomeDevices.Kasa-2.0.0-preview2

### DIFF
--- a/doc/api-list/Smdn.TPSmartHomeDevices.Kasa/Smdn.TPSmartHomeDevices.Kasa-net6.0.apilist.cs
+++ b/doc/api-list/Smdn.TPSmartHomeDevices.Kasa/Smdn.TPSmartHomeDevices.Kasa-net6.0.apilist.cs
@@ -1,7 +1,7 @@
-// Smdn.TPSmartHomeDevices.Kasa.dll (Smdn.TPSmartHomeDevices.Kasa-2.0.0-preview1)
+// Smdn.TPSmartHomeDevices.Kasa.dll (Smdn.TPSmartHomeDevices.Kasa-2.0.0-preview2)
 //   Name: Smdn.TPSmartHomeDevices.Kasa
 //   AssemblyVersion: 2.0.0.0
-//   InformationalVersion: 2.0.0-preview1+79057c306c2fede642a92b623a95cbb150e83873
+//   InformationalVersion: 2.0.0-preview2+d001e07a3ea43a47290d9e9d2f4d582e14caa297
 //   TargetFramework: .NETCoreApp,Version=v6.0
 //   Configuration: Release
 //   Referenced assemblies:
@@ -38,7 +38,7 @@ using Smdn.TPSmartHomeDevices.Kasa.Protocol;
 namespace Smdn.TPSmartHomeDevices.Kasa {
   public class HS105 :
     KasaDevice,
-    ISmartPlug
+    ISmartDevice
   {
     public static HS105 Create<TAddress>(TAddress deviceAddress, IServiceProvider serviceProvider) where TAddress : notnull {}
 
@@ -49,6 +49,7 @@ namespace Smdn.TPSmartHomeDevices.Kasa {
 
     public ValueTask<bool> GetOnOffStateAsync(CancellationToken cancellationToken = default) {}
     public ValueTask SetOnOffStateAsync(bool newOnOffState, CancellationToken cancellationToken = default) {}
+    async ValueTask<IDeviceInfo> ISmartDevice.GetDeviceInfoAsync(CancellationToken cancellationToken) {}
     public ValueTask TurnOffAsync(CancellationToken cancellationToken = default) {}
     public ValueTask TurnOnAsync(CancellationToken cancellationToken = default) {}
   }
@@ -70,6 +71,7 @@ namespace Smdn.TPSmartHomeDevices.Kasa {
     public ValueTask SetColorAsync(int hue, int saturation, int? brightness = null, TimeSpan transitionPeriod = default, CancellationToken cancellationToken = default) {}
     public ValueTask SetColorTemperatureAsync(int colorTemperature, int? brightness = null, TimeSpan transitionPeriod = default, CancellationToken cancellationToken = default) {}
     public ValueTask SetOnOffStateAsync(bool newOnOffState, TimeSpan transitionPeriod = default, CancellationToken cancellationToken = default) {}
+    async ValueTask<IDeviceInfo> ISmartDevice.GetDeviceInfoAsync(CancellationToken cancellationToken) {}
     ValueTask ISmartDevice.SetOnOffStateAsync(bool newOnOffState, CancellationToken cancellationToken) {}
     public ValueTask TurnOffAsync(TimeSpan transitionPeriod = default, CancellationToken cancellationToken = default) {}
     public ValueTask TurnOnAsync(TimeSpan transitionPeriod = default, CancellationToken cancellationToken = default) {}
@@ -99,6 +101,8 @@ namespace Smdn.TPSmartHomeDevices.Kasa {
 
     protected virtual void Dispose(bool disposing) {}
     public void Dispose() {}
+    public ValueTask<KasaDeviceInfo?> GetDeviceInfoAsync(CancellationToken cancellationToken = default) {}
+    protected ValueTask<TSysInfo> GetSysInfoAsync<TSysInfo>(Func<JsonElement, TSysInfo> composeResult, CancellationToken cancellationToken = default) {}
     public ValueTask<EndPoint> ResolveEndPointAsync(CancellationToken cancellationToken = default) {}
     protected ValueTask SendRequestAsync<TMethodParameter>(JsonEncodedText module, JsonEncodedText method, TMethodParameter parameters, CancellationToken cancellationToken) {}
     protected ValueTask<TMethodResult> SendRequestAsync<TMethodParameter, TMethodResult>(JsonEncodedText module, JsonEncodedText method, TMethodParameter parameters, Func<JsonElement, TMethodResult> composeResult, CancellationToken cancellationToken) {}
@@ -116,6 +120,57 @@ namespace Smdn.TPSmartHomeDevices.Kasa {
 
   public static class KasaDeviceExceptionHandlerServiceCollectionExtensions {
     public static IServiceCollection AddKasaDeviceExceptionHandler(this IServiceCollection services, KasaDeviceExceptionHandler exceptionHandler) {}
+  }
+
+  public class KasaDeviceInfo : IDeviceInfo {
+    public KasaDeviceInfo() {}
+
+    public string? Description { get; }
+    [JsonConverter(typeof(Base16ByteArrayJsonConverter))]
+    [JsonPropertyName("fwId")]
+    public byte[]? FirmwareId { get; init; }
+    [JsonPropertyName("sw_ver")]
+    public string? FirmwareVersion { get; init; }
+    [JsonConverter(typeof(Base16ByteArrayJsonConverter))]
+    [JsonPropertyName("hwId")]
+    public byte[]? HardwareId { get; init; }
+    [JsonPropertyName("hw_ver")]
+    public string? HardwareVersion { get; init; }
+    [JsonConverter(typeof(Base16ByteArrayJsonConverter))]
+    [JsonPropertyName("deviceId")]
+    public byte[]? Id { get; init; }
+    [Obsolete("This property is intended to be used only for JSON deserialization. Refer 'Description' to get the value.")]
+    [JsonPropertyName("description")]
+    public string? JsonPropertyDescription { get; set; }
+    [Obsolete("This property is intended to be used only for JSON deserialization. Refer 'Description' to get the value.")]
+    [JsonPropertyName("dev_name")]
+    public string? JsonPropertyDevName { get; set; }
+    [Obsolete("This property is intended to be used only for JSON deserialization. Refer 'MacAddress' to get the value.")]
+    [JsonConverter(typeof(MacAddressJsonConverter))]
+    [JsonPropertyName("mac")]
+    public PhysicalAddress? JsonPropertyMac { get; init; }
+    [Obsolete("This property is intended to be used only for JSON deserialization. Refer 'MacAddress' to get the value.")]
+    [JsonConverter(typeof(MacAddressJsonConverter))]
+    [JsonPropertyName("mic_mac")]
+    public PhysicalAddress? JsonPropertyMicMac { get; init; }
+    [Obsolete("This property is intended to be used only for JSON deserialization. Refer 'TypeName' to get the value.")]
+    [JsonPropertyName("mic_type")]
+    public string? JsonPropertyMicType { get; set; }
+    [Obsolete("This property is intended to be used only for JSON deserialization. Refer 'TypeName' to get the value.")]
+    [JsonPropertyName("type")]
+    public string? JsonPropertyType { get; set; }
+    public PhysicalAddress? MacAddress { get; }
+    [JsonPropertyName("model")]
+    public string? ModelName { get; init; }
+    [JsonPropertyName("rssi")]
+    public decimal? NetworkRssi { get; init; }
+    [JsonConverter(typeof(Base16ByteArrayJsonConverter))]
+    [JsonPropertyName("oemId")]
+    public byte[]? OemId { get; init; }
+    ReadOnlySpan<byte> IDeviceInfo.Id { get; }
+    [JsonIgnore]
+    public DateTimeOffset TimeStamp { get; }
+    public string? TypeName { get; }
   }
 
   public class KasaDisconnectedException : KasaProtocolException {

--- a/doc/api-list/Smdn.TPSmartHomeDevices.Kasa/Smdn.TPSmartHomeDevices.Kasa-net8.0.apilist.cs
+++ b/doc/api-list/Smdn.TPSmartHomeDevices.Kasa/Smdn.TPSmartHomeDevices.Kasa-net8.0.apilist.cs
@@ -1,7 +1,7 @@
-// Smdn.TPSmartHomeDevices.Kasa.dll (Smdn.TPSmartHomeDevices.Kasa-2.0.0-preview1)
+// Smdn.TPSmartHomeDevices.Kasa.dll (Smdn.TPSmartHomeDevices.Kasa-2.0.0-preview2)
 //   Name: Smdn.TPSmartHomeDevices.Kasa
 //   AssemblyVersion: 2.0.0.0
-//   InformationalVersion: 2.0.0-preview1+79057c306c2fede642a92b623a95cbb150e83873
+//   InformationalVersion: 2.0.0-preview2+d001e07a3ea43a47290d9e9d2f4d582e14caa297
 //   TargetFramework: .NETCoreApp,Version=v8.0
 //   Configuration: Release
 //   Referenced assemblies:
@@ -38,7 +38,7 @@ using Smdn.TPSmartHomeDevices.Kasa.Protocol;
 namespace Smdn.TPSmartHomeDevices.Kasa {
   public class HS105 :
     KasaDevice,
-    ISmartPlug
+    ISmartDevice
   {
     public static HS105 Create<TAddress>(TAddress deviceAddress, IServiceProvider serviceProvider) where TAddress : notnull {}
 
@@ -49,6 +49,7 @@ namespace Smdn.TPSmartHomeDevices.Kasa {
 
     public ValueTask<bool> GetOnOffStateAsync(CancellationToken cancellationToken = default) {}
     public ValueTask SetOnOffStateAsync(bool newOnOffState, CancellationToken cancellationToken = default) {}
+    async ValueTask<IDeviceInfo> ISmartDevice.GetDeviceInfoAsync(CancellationToken cancellationToken) {}
     public ValueTask TurnOffAsync(CancellationToken cancellationToken = default) {}
     public ValueTask TurnOnAsync(CancellationToken cancellationToken = default) {}
   }
@@ -70,6 +71,7 @@ namespace Smdn.TPSmartHomeDevices.Kasa {
     public ValueTask SetColorAsync(int hue, int saturation, int? brightness = null, TimeSpan transitionPeriod = default, CancellationToken cancellationToken = default) {}
     public ValueTask SetColorTemperatureAsync(int colorTemperature, int? brightness = null, TimeSpan transitionPeriod = default, CancellationToken cancellationToken = default) {}
     public ValueTask SetOnOffStateAsync(bool newOnOffState, TimeSpan transitionPeriod = default, CancellationToken cancellationToken = default) {}
+    async ValueTask<IDeviceInfo> ISmartDevice.GetDeviceInfoAsync(CancellationToken cancellationToken) {}
     ValueTask ISmartDevice.SetOnOffStateAsync(bool newOnOffState, CancellationToken cancellationToken) {}
     public ValueTask TurnOffAsync(TimeSpan transitionPeriod = default, CancellationToken cancellationToken = default) {}
     public ValueTask TurnOnAsync(TimeSpan transitionPeriod = default, CancellationToken cancellationToken = default) {}
@@ -99,6 +101,8 @@ namespace Smdn.TPSmartHomeDevices.Kasa {
 
     protected virtual void Dispose(bool disposing) {}
     public void Dispose() {}
+    public ValueTask<KasaDeviceInfo?> GetDeviceInfoAsync(CancellationToken cancellationToken = default) {}
+    protected ValueTask<TSysInfo> GetSysInfoAsync<TSysInfo>(Func<JsonElement, TSysInfo> composeResult, CancellationToken cancellationToken = default) {}
     public ValueTask<EndPoint> ResolveEndPointAsync(CancellationToken cancellationToken = default) {}
     protected ValueTask SendRequestAsync<TMethodParameter>(JsonEncodedText module, JsonEncodedText method, TMethodParameter parameters, CancellationToken cancellationToken) {}
     protected ValueTask<TMethodResult> SendRequestAsync<TMethodParameter, TMethodResult>(JsonEncodedText module, JsonEncodedText method, TMethodParameter parameters, Func<JsonElement, TMethodResult> composeResult, CancellationToken cancellationToken) {}
@@ -116,6 +120,37 @@ namespace Smdn.TPSmartHomeDevices.Kasa {
 
   public static class KasaDeviceExceptionHandlerServiceCollectionExtensions {
     public static IServiceCollection AddKasaDeviceExceptionHandler(this IServiceCollection services, KasaDeviceExceptionHandler exceptionHandler) {}
+  }
+
+  public class KasaDeviceInfo : IDeviceInfo {
+    public KasaDeviceInfo() {}
+
+    public string? Description { get; }
+    [JsonConverter(typeof(Base16ByteArrayJsonConverter))]
+    [JsonPropertyName("fwId")]
+    public byte[]? FirmwareId { get; init; }
+    [JsonPropertyName("sw_ver")]
+    public string? FirmwareVersion { get; init; }
+    [JsonConverter(typeof(Base16ByteArrayJsonConverter))]
+    [JsonPropertyName("hwId")]
+    public byte[]? HardwareId { get; init; }
+    [JsonPropertyName("hw_ver")]
+    public string? HardwareVersion { get; init; }
+    [JsonConverter(typeof(Base16ByteArrayJsonConverter))]
+    [JsonPropertyName("deviceId")]
+    public byte[]? Id { get; init; }
+    public PhysicalAddress? MacAddress { get; }
+    [JsonPropertyName("model")]
+    public string? ModelName { get; init; }
+    [JsonPropertyName("rssi")]
+    public decimal? NetworkRssi { get; init; }
+    [JsonConverter(typeof(Base16ByteArrayJsonConverter))]
+    [JsonPropertyName("oemId")]
+    public byte[]? OemId { get; init; }
+    ReadOnlySpan<byte> IDeviceInfo.Id { get; }
+    [JsonIgnore]
+    public DateTimeOffset TimeStamp { get; }
+    public string? TypeName { get; }
   }
 
   public class KasaDisconnectedException : KasaProtocolException {

--- a/doc/api-list/Smdn.TPSmartHomeDevices.Kasa/Smdn.TPSmartHomeDevices.Kasa-netstandard2.1.apilist.cs
+++ b/doc/api-list/Smdn.TPSmartHomeDevices.Kasa/Smdn.TPSmartHomeDevices.Kasa-netstandard2.1.apilist.cs
@@ -1,7 +1,7 @@
-// Smdn.TPSmartHomeDevices.Kasa.dll (Smdn.TPSmartHomeDevices.Kasa-2.0.0-preview1)
+// Smdn.TPSmartHomeDevices.Kasa.dll (Smdn.TPSmartHomeDevices.Kasa-2.0.0-preview2)
 //   Name: Smdn.TPSmartHomeDevices.Kasa
 //   AssemblyVersion: 2.0.0.0
-//   InformationalVersion: 2.0.0-preview1+79057c306c2fede642a92b623a95cbb150e83873
+//   InformationalVersion: 2.0.0-preview2+d001e07a3ea43a47290d9e9d2f4d582e14caa297
 //   TargetFramework: .NETStandard,Version=v2.1
 //   Configuration: Release
 //   Referenced assemblies:
@@ -30,7 +30,7 @@ using Smdn.TPSmartHomeDevices.Kasa.Protocol;
 namespace Smdn.TPSmartHomeDevices.Kasa {
   public class HS105 :
     KasaDevice,
-    ISmartPlug
+    ISmartDevice
   {
     public static HS105 Create<TAddress>(TAddress deviceAddress, IServiceProvider serviceProvider) where TAddress : notnull {}
 
@@ -41,6 +41,7 @@ namespace Smdn.TPSmartHomeDevices.Kasa {
 
     public ValueTask<bool> GetOnOffStateAsync(CancellationToken cancellationToken = default) {}
     public ValueTask SetOnOffStateAsync(bool newOnOffState, CancellationToken cancellationToken = default) {}
+    async ValueTask<IDeviceInfo> ISmartDevice.GetDeviceInfoAsync(CancellationToken cancellationToken) {}
     public ValueTask TurnOffAsync(CancellationToken cancellationToken = default) {}
     public ValueTask TurnOnAsync(CancellationToken cancellationToken = default) {}
   }
@@ -62,6 +63,7 @@ namespace Smdn.TPSmartHomeDevices.Kasa {
     public ValueTask SetColorAsync(int hue, int saturation, int? brightness = null, TimeSpan transitionPeriod = default, CancellationToken cancellationToken = default) {}
     public ValueTask SetColorTemperatureAsync(int colorTemperature, int? brightness = null, TimeSpan transitionPeriod = default, CancellationToken cancellationToken = default) {}
     public ValueTask SetOnOffStateAsync(bool newOnOffState, TimeSpan transitionPeriod = default, CancellationToken cancellationToken = default) {}
+    async ValueTask<IDeviceInfo> ISmartDevice.GetDeviceInfoAsync(CancellationToken cancellationToken) {}
     ValueTask ISmartDevice.SetOnOffStateAsync(bool newOnOffState, CancellationToken cancellationToken) {}
     public ValueTask TurnOffAsync(TimeSpan transitionPeriod = default, CancellationToken cancellationToken = default) {}
     public ValueTask TurnOnAsync(TimeSpan transitionPeriod = default, CancellationToken cancellationToken = default) {}
@@ -90,6 +92,8 @@ namespace Smdn.TPSmartHomeDevices.Kasa {
 
     protected virtual void Dispose(bool disposing) {}
     public void Dispose() {}
+    public ValueTask<KasaDeviceInfo?> GetDeviceInfoAsync(CancellationToken cancellationToken = default) {}
+    protected ValueTask<TSysInfo> GetSysInfoAsync<TSysInfo>(Func<JsonElement, TSysInfo> composeResult, CancellationToken cancellationToken = default) {}
     public ValueTask<EndPoint> ResolveEndPointAsync(CancellationToken cancellationToken = default) {}
     protected ValueTask SendRequestAsync<TMethodParameter>(JsonEncodedText module, JsonEncodedText method, TMethodParameter parameters, CancellationToken cancellationToken) {}
     protected ValueTask<TMethodResult> SendRequestAsync<TMethodParameter, TMethodResult>(JsonEncodedText module, JsonEncodedText method, TMethodParameter parameters, Func<JsonElement, TMethodResult> composeResult, CancellationToken cancellationToken) {}
@@ -107,6 +111,57 @@ namespace Smdn.TPSmartHomeDevices.Kasa {
 
   public static class KasaDeviceExceptionHandlerServiceCollectionExtensions {
     public static IServiceCollection AddKasaDeviceExceptionHandler(this IServiceCollection services, KasaDeviceExceptionHandler exceptionHandler) {}
+  }
+
+  public class KasaDeviceInfo : IDeviceInfo {
+    public KasaDeviceInfo() {}
+
+    public string? Description { get; }
+    [JsonConverter(typeof(Base16ByteArrayJsonConverter))]
+    [JsonPropertyName("fwId")]
+    public byte[]? FirmwareId { get; init; }
+    [JsonPropertyName("sw_ver")]
+    public string? FirmwareVersion { get; init; }
+    [JsonConverter(typeof(Base16ByteArrayJsonConverter))]
+    [JsonPropertyName("hwId")]
+    public byte[]? HardwareId { get; init; }
+    [JsonPropertyName("hw_ver")]
+    public string? HardwareVersion { get; init; }
+    [JsonConverter(typeof(Base16ByteArrayJsonConverter))]
+    [JsonPropertyName("deviceId")]
+    public byte[]? Id { get; init; }
+    [Obsolete("This property is intended to be used only for JSON deserialization. Refer 'Description' to get the value.")]
+    [JsonPropertyName("description")]
+    public string? JsonPropertyDescription { get; set; }
+    [Obsolete("This property is intended to be used only for JSON deserialization. Refer 'Description' to get the value.")]
+    [JsonPropertyName("dev_name")]
+    public string? JsonPropertyDevName { get; set; }
+    [Obsolete("This property is intended to be used only for JSON deserialization. Refer 'MacAddress' to get the value.")]
+    [JsonConverter(typeof(MacAddressJsonConverter))]
+    [JsonPropertyName("mac")]
+    public PhysicalAddress? JsonPropertyMac { get; init; }
+    [Obsolete("This property is intended to be used only for JSON deserialization. Refer 'MacAddress' to get the value.")]
+    [JsonConverter(typeof(MacAddressJsonConverter))]
+    [JsonPropertyName("mic_mac")]
+    public PhysicalAddress? JsonPropertyMicMac { get; init; }
+    [Obsolete("This property is intended to be used only for JSON deserialization. Refer 'TypeName' to get the value.")]
+    [JsonPropertyName("mic_type")]
+    public string? JsonPropertyMicType { get; set; }
+    [Obsolete("This property is intended to be used only for JSON deserialization. Refer 'TypeName' to get the value.")]
+    [JsonPropertyName("type")]
+    public string? JsonPropertyType { get; set; }
+    public PhysicalAddress? MacAddress { get; }
+    [JsonPropertyName("model")]
+    public string? ModelName { get; init; }
+    [JsonPropertyName("rssi")]
+    public decimal? NetworkRssi { get; init; }
+    [JsonConverter(typeof(Base16ByteArrayJsonConverter))]
+    [JsonPropertyName("oemId")]
+    public byte[]? OemId { get; init; }
+    ReadOnlySpan<byte> IDeviceInfo.Id { get; }
+    [JsonIgnore]
+    public DateTimeOffset TimeStamp { get; }
+    public string? TypeName { get; }
   }
 
   public class KasaDisconnectedException : KasaProtocolException {


### PR DESCRIPTION
Automatically generated by workflow [Generate release target #25](https://github.com/smdn/Smdn.TPSmartHomeDevices/actions/runs/7544300056).

# Release target
- package_target_tag: `new-release/main/Smdn.TPSmartHomeDevices.Kasa-2.0.0-preview2`
- package_prevver_ref: `releases/Smdn.TPSmartHomeDevices.Kasa-2.0.0-preview1`
- package_prevver_tag: `releases/Smdn.TPSmartHomeDevices.Kasa-2.0.0-preview1`
- package_id: `Smdn.TPSmartHomeDevices.Kasa`
- package_id_with_version: `Smdn.TPSmartHomeDevices.Kasa-2.0.0-preview2`
- package_version: `2.0.0-preview2`
- package_branch: `main`
- release_working_branch: `releases/Smdn.TPSmartHomeDevices.Kasa-2.0.0-preview2-1705421173`
- release_tag: `releases/Smdn.TPSmartHomeDevices.Kasa-2.0.0-preview2`
- release_prerelease: `True` ❗Change this value to `true` to publish release note as a prerelease.
- release_draft: `false` ❗Change this value to `true` to publish release note as a draft.
- release_note_url: [`https://gist.github.com/smdn/2d4450558b861039cbe66226649ea84c`](https://gist.github.com/smdn/2d4450558b861039cbe66226649ea84c)
- artifact_name_nupkg: `Smdn.TPSmartHomeDevices.Kasa.2.0.0-preview2.nupkg` ❗Remove this line or change this value to empty to prevent publishing packages.

# .nuspec diff
```diff
--- Smdn.TPSmartHomeDevices.Kasa.latest.nuspec
+++ Smdn.TPSmartHomeDevices.Kasa.2.0.0-preview2.nuspec
@@ -1,33 +1,44 @@
 <?xml version="1.0" encoding="utf-8"?>
-<package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
+<package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
   <metadata>
     <id>Smdn.TPSmartHomeDevices.Kasa</id>
-    <version>2.0.0-preview1</version>
+    <version>2.0.0-preview2</version>
     <title>Smdn.TPSmartHomeDevices.Kasa</title>
     <authors>smdn</authors>
     <license type="expression">MIT</license>
     <licenseUrl>https://licenses.nuget.org/MIT</licenseUrl>
     <icon>Smdn.TPSmartHomeDevices.Kasa.png</icon>
     <readme>README.md</readme>
     <projectUrl>https://github.com/smdn/Smdn.TPSmartHomeDevices/</projectUrl>
     <description>Provides APIs for operating Kasa devices, the TP-Link smart home devices.</description>
-    <releaseNotes>https://github.com/smdn/Smdn.TPSmartHomeDevices/releases/tag/releases%2FSmdn.TPSmartHomeDevices.Kasa-2.0.0-preview1</releaseNotes>
+    <releaseNotes>https://github.com/smdn/Smdn.TPSmartHomeDevices/releases/tag/releases%2FSmdn.TPSmartHomeDevices.Kasa-2.0.0-preview2</releaseNotes>
     <copyright>Copyright © 2023 smdn</copyright>
     <tags>smdn.jp tplink-kasa,kasa,HS105,KL130,smarthome,homeautomation,smartdevice</tags>
-    <repository type="git" url="https://github.com/smdn/Smdn.TPSmartHomeDevices" branch="main" commit="79057c306c2fede642a92b623a95cbb150e83873" />
+    <repository type="git" url="https://github.com/smdn/Smdn.TPSmartHomeDevices" commit="d001e07a3ea43a47290d9e9d2f4d582e14caa297" />
     <dependencies>
       <group targetFramework="net6.0">
         <dependency id="Microsoft.Extensions.Logging.Abstractions" version="6.0.0" exclude="Build,Analyzers" />
-        <dependency id="Smdn.TPSmartHomeDevices.Primitives" version="1.1.0-preview1" exclude="Build,Analyzers" />
+        <dependency id="Smdn.TPSmartHomeDevices.Primitives" version="1.1.0-preview2" exclude="Build,Analyzers" />
       </group>
       <group targetFramework="net8.0">
         <dependency id="Microsoft.Extensions.Logging.Abstractions" version="6.0.0" exclude="Build,Analyzers" />
-        <dependency id="Smdn.TPSmartHomeDevices.Primitives" version="1.1.0-preview1" exclude="Build,Analyzers" />
+        <dependency id="Smdn.TPSmartHomeDevices.Primitives" version="1.1.0-preview2" exclude="Build,Analyzers" />
       </group>
       <group targetFramework=".NETStandard2.1">
         <dependency id="Microsoft.Extensions.Logging.Abstractions" version="6.0.0" exclude="Build,Analyzers" />
-        <dependency id="Smdn.TPSmartHomeDevices.Primitives" version="1.1.0-preview1" exclude="Build,Analyzers" />
+        <dependency id="Smdn.TPSmartHomeDevices.Primitives" version="1.1.0-preview2" exclude="Build,Analyzers" />
       </group>
     </dependencies>
   </metadata>
+  <files>
+    <file src="/home/runner/work/Smdn.TPSmartHomeDevices/Smdn.TPSmartHomeDevices/src/Smdn.TPSmartHomeDevices.Kasa/bin/Release/net6.0/Smdn.TPSmartHomeDevices.Kasa.dll" target="lib/net6.0/Smdn.TPSmartHomeDevices.Kasa.dll" />
+    <file src="/home/runner/work/Smdn.TPSmartHomeDevices/Smdn.TPSmartHomeDevices/src/Smdn.TPSmartHomeDevices.Kasa/bin/Release/net6.0/Smdn.TPSmartHomeDevices.Kasa.xml" target="lib/net6.0/Smdn.TPSmartHomeDevices.Kasa.xml" />
+    <file src="/home/runner/work/Smdn.TPSmartHomeDevices/Smdn.TPSmartHomeDevices/src/Smdn.TPSmartHomeDevices.Kasa/bin/Release/net8.0/Smdn.TPSmartHomeDevices.Kasa.dll" target="lib/net8.0/Smdn.TPSmartHomeDevices.Kasa.dll" />
+    <file src="/home/runner/work/Smdn.TPSmartHomeDevices/Smdn.TPSmartHomeDevices/src/Smdn.TPSmartHomeDevices.Kasa/bin/Release/net8.0/Smdn.TPSmartHomeDevices.Kasa.xml" target="lib/net8.0/Smdn.TPSmartHomeDevices.Kasa.xml" />
+    <file src="/home/runner/work/Smdn.TPSmartHomeDevices/Smdn.TPSmartHomeDevices/src/Smdn.TPSmartHomeDevices.Kasa/bin/Release/netstandard2.1/Smdn.TPSmartHomeDevices.Kasa.dll" target="lib/netstandard2.1/Smdn.TPSmartHomeDevices.Kasa.dll" />
+    <file src="/home/runner/work/Smdn.TPSmartHomeDevices/Smdn.TPSmartHomeDevices/src/Smdn.TPSmartHomeDevices.Kasa/bin/Release/netstandard2.1/Smdn.TPSmartHomeDevices.Kasa.xml" target="lib/netstandard2.1/Smdn.TPSmartHomeDevices.Kasa.xml" />
+    <file src="/home/runner/work/Smdn.TPSmartHomeDevices/Smdn.TPSmartHomeDevices/.nuget/packages/smdn.msbuild.projectassets.common/1.4.0/project/images/package-icon.png" target="Smdn.TPSmartHomeDevices.Kasa.png" />
+    <file src="/home/runner/work/Smdn.TPSmartHomeDevices/Smdn.TPSmartHomeDevices/ThirdPartyNotices.md" target="ThirdPartyNotices.md" />
+    <file src="/home/runner/work/Smdn.TPSmartHomeDevices/Smdn.TPSmartHomeDevices/src/Smdn.TPSmartHomeDevices.Kasa/bin/Release/README.md" target="README.md" />
+  </files>
 </package>
\ No newline at end of file
```

