### PR TITLE
Release main/Smdn.TPSmartHomeDevices.Primitives-1.1.0

### DIFF
--- a/doc/api-list/Smdn.TPSmartHomeDevices.Primitives/Smdn.TPSmartHomeDevices.Primitives-net6.0.apilist.cs
+++ b/doc/api-list/Smdn.TPSmartHomeDevices.Primitives/Smdn.TPSmartHomeDevices.Primitives-net6.0.apilist.cs
@@ -1,7 +1,7 @@
-// Smdn.TPSmartHomeDevices.Primitives.dll (Smdn.TPSmartHomeDevices.Primitives-1.1.0-preview3)
+// Smdn.TPSmartHomeDevices.Primitives.dll (Smdn.TPSmartHomeDevices.Primitives-1.1.0)
 //   Name: Smdn.TPSmartHomeDevices.Primitives
 //   AssemblyVersion: 1.1.0.0
-//   InformationalVersion: 1.1.0-preview3+997d1abe73c225c5c322bcb1043abfc410f19baf
+//   InformationalVersion: 1.1.0+62f4dfe508fe750dce82db61618115e330ed4321
 //   TargetFramework: .NETCoreApp,Version=v6.0
 //   Configuration: Release
 //   Referenced assemblies:

--- a/doc/api-list/Smdn.TPSmartHomeDevices.Primitives/Smdn.TPSmartHomeDevices.Primitives-net8.0.apilist.cs
+++ b/doc/api-list/Smdn.TPSmartHomeDevices.Primitives/Smdn.TPSmartHomeDevices.Primitives-net8.0.apilist.cs
@@ -1,7 +1,7 @@
-// Smdn.TPSmartHomeDevices.Primitives.dll (Smdn.TPSmartHomeDevices.Primitives-1.1.0-preview3)
+// Smdn.TPSmartHomeDevices.Primitives.dll (Smdn.TPSmartHomeDevices.Primitives-1.1.0)
 //   Name: Smdn.TPSmartHomeDevices.Primitives
 //   AssemblyVersion: 1.1.0.0
-//   InformationalVersion: 1.1.0-preview3+997d1abe73c225c5c322bcb1043abfc410f19baf
+//   InformationalVersion: 1.1.0+62f4dfe508fe750dce82db61618115e330ed4321
 //   TargetFramework: .NETCoreApp,Version=v8.0
 //   Configuration: Release
 //   Referenced assemblies:

--- a/doc/api-list/Smdn.TPSmartHomeDevices.Primitives/Smdn.TPSmartHomeDevices.Primitives-netstandard2.0.apilist.cs
+++ b/doc/api-list/Smdn.TPSmartHomeDevices.Primitives/Smdn.TPSmartHomeDevices.Primitives-netstandard2.0.apilist.cs
@@ -1,7 +1,7 @@
-// Smdn.TPSmartHomeDevices.Primitives.dll (Smdn.TPSmartHomeDevices.Primitives-1.1.0-preview3)
+// Smdn.TPSmartHomeDevices.Primitives.dll (Smdn.TPSmartHomeDevices.Primitives-1.1.0)
 //   Name: Smdn.TPSmartHomeDevices.Primitives
 //   AssemblyVersion: 1.1.0.0
-//   InformationalVersion: 1.1.0-preview3+997d1abe73c225c5c322bcb1043abfc410f19baf
+//   InformationalVersion: 1.1.0+62f4dfe508fe750dce82db61618115e330ed4321
 //   TargetFramework: .NETStandard,Version=v2.0
 //   Configuration: Release
 //   Referenced assemblies:

--- a/doc/api-list/Smdn.TPSmartHomeDevices.Primitives/Smdn.TPSmartHomeDevices.Primitives-netstandard2.1.apilist.cs
+++ b/doc/api-list/Smdn.TPSmartHomeDevices.Primitives/Smdn.TPSmartHomeDevices.Primitives-netstandard2.1.apilist.cs
@@ -1,7 +1,7 @@
-// Smdn.TPSmartHomeDevices.Primitives.dll (Smdn.TPSmartHomeDevices.Primitives-1.1.0-preview3)
+// Smdn.TPSmartHomeDevices.Primitives.dll (Smdn.TPSmartHomeDevices.Primitives-1.1.0)
 //   Name: Smdn.TPSmartHomeDevices.Primitives
 //   AssemblyVersion: 1.1.0.0
-//   InformationalVersion: 1.1.0-preview3+997d1abe73c225c5c322bcb1043abfc410f19baf
+//   InformationalVersion: 1.1.0+62f4dfe508fe750dce82db61618115e330ed4321
 //   TargetFramework: .NETStandard,Version=v2.1
 //   Configuration: Release
 //   Referenced assemblies:


### PR DESCRIPTION
Automatically generated by workflow [Generate release target #30](https://github.com/smdn/Smdn.TPSmartHomeDevices/actions/runs/7627937600).

# Release target
- package_target_tag: `new-release/main/Smdn.TPSmartHomeDevices.Primitives-1.1.0`
- package_prevver_ref: `releases/Smdn.TPSmartHomeDevices.Primitives-1.1.0-preview3`
- package_prevver_tag: `releases/Smdn.TPSmartHomeDevices.Primitives-1.1.0-preview3`
- package_id: `Smdn.TPSmartHomeDevices.Primitives`
- package_id_with_version: `Smdn.TPSmartHomeDevices.Primitives-1.1.0`
- package_version: `1.1.0`
- package_branch: `main`
- release_working_branch: `releases/Smdn.TPSmartHomeDevices.Primitives-1.1.0-1706023322`
- release_tag: `releases/Smdn.TPSmartHomeDevices.Primitives-1.1.0`
- release_prerelease: `False` ❗Change this value to `true` to publish release note as a prerelease.
- release_draft: `false` ❗Change this value to `true` to publish release note as a draft.
- release_note_url: [`https://gist.github.com/smdn/c1e2b7e1622bdc959a5ea02999e0f740`](https://gist.github.com/smdn/c1e2b7e1622bdc959a5ea02999e0f740)
- artifact_name_nupkg: `Smdn.TPSmartHomeDevices.Primitives.1.1.0.nupkg` ❗Remove this line or change this value to empty to prevent publishing packages.

# .nuspec diff
```diff
--- Smdn.TPSmartHomeDevices.Primitives.latest.nuspec
+++ Smdn.TPSmartHomeDevices.Primitives.1.1.0.nuspec
@@ -1,41 +1,53 @@
 <?xml version="1.0" encoding="utf-8"?>
-<package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
+<package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
   <metadata>
     <id>Smdn.TPSmartHomeDevices.Primitives</id>
-    <version>1.1.0-preview3</version>
+    <version>1.1.0</version>
     <title>Smdn.TPSmartHomeDevices.Primitives</title>
     <authors>smdn</authors>
     <license type="expression">MIT</license>
     <licenseUrl>https://licenses.nuget.org/MIT</licenseUrl>
     <icon>Smdn.TPSmartHomeDevices.Primitives.png</icon>
     <readme>README.md</readme>
     <projectUrl>https://github.com/smdn/Smdn.TPSmartHomeDevices/</projectUrl>
     <description>Provides common types for Smdn.TPSmartHomeDevices.Tapo and Smdn.TPSmartHomeDevices.Kasa, including abstraction interfaces, extension methods and custom JsonConverter's. This library does not provide any specific implementations to operate Kasa and Tapo devices.</description>
-    <releaseNotes>https://github.com/smdn/Smdn.TPSmartHomeDevices/releases/tag/releases%2FSmdn.TPSmartHomeDevices.Primitives-1.1.0-preview3</releaseNotes>
+    <releaseNotes>https://github.com/smdn/Smdn.TPSmartHomeDevices/releases/tag/releases%2FSmdn.TPSmartHomeDevices.Primitives-1.1.0</releaseNotes>
     <copyright>Copyright © 2023 smdn</copyright>
     <tags>smdn.jp tplink-kasa,kasa,tplink-tapo,tapo,common,smarthome,homeautomation,smartdevice</tags>
-    <repository type="git" url="https://github.com/smdn/Smdn.TPSmartHomeDevices" branch="main" commit="997d1abe73c225c5c322bcb1043abfc410f19baf" />
+    <repository type="git" url="https://github.com/smdn/Smdn.TPSmartHomeDevices" commit="62f4dfe508fe750dce82db61618115e330ed4321" />
     <dependencies>
       <group targetFramework="net6.0">
         <dependency id="Microsoft.Extensions.DependencyInjection.Abstractions" version="6.0.0" exclude="Build,Analyzers" />
         <dependency id="Smdn.Fundamental.PrintableEncoding.Hexadecimal" version="3.0.1" exclude="Build,Analyzers" />
         <dependency id="System.Text.Json" version="6.0.0" exclude="Build,Analyzers" />
       </group>
       <group targetFramework="net8.0">
         <dependency id="Microsoft.Extensions.DependencyInjection.Abstractions" version="6.0.0" exclude="Build,Analyzers" />
         <dependency id="Smdn.Fundamental.PrintableEncoding.Hexadecimal" version="3.0.1" exclude="Build,Analyzers" />
         <dependency id="System.Text.Json" version="6.0.0" exclude="Build,Analyzers" />
       </group>
       <group targetFramework=".NETStandard2.0">
         <dependency id="Microsoft.Extensions.DependencyInjection.Abstractions" version="6.0.0" exclude="Build,Analyzers" />
         <dependency id="Smdn.Fundamental.PrintableEncoding.Hexadecimal" version="3.0.1" exclude="Build,Analyzers" />
         <dependency id="System.Text.Json" version="6.0.0" exclude="Build,Analyzers" />
       </group>
       <group targetFramework=".NETStandard2.1">
         <dependency id="Microsoft.Extensions.DependencyInjection.Abstractions" version="6.0.0" exclude="Build,Analyzers" />
         <dependency id="Smdn.Fundamental.PrintableEncoding.Hexadecimal" version="3.0.1" exclude="Build,Analyzers" />
         <dependency id="System.Text.Json" version="6.0.0" exclude="Build,Analyzers" />
       </group>
     </dependencies>
   </metadata>
+  <files>
+    <file src="/home/runner/work/Smdn.TPSmartHomeDevices/Smdn.TPSmartHomeDevices/src/Smdn.TPSmartHomeDevices.Primitives/bin/Release/net6.0/Smdn.TPSmartHomeDevices.Primitives.dll" target="lib/net6.0/Smdn.TPSmartHomeDevices.Primitives.dll" />
+    <file src="/home/runner/work/Smdn.TPSmartHomeDevices/Smdn.TPSmartHomeDevices/src/Smdn.TPSmartHomeDevices.Primitives/bin/Release/net6.0/Smdn.TPSmartHomeDevices.Primitives.xml" target="lib/net6.0/Smdn.TPSmartHomeDevices.Primitives.xml" />
+    <file src="/home/runner/work/Smdn.TPSmartHomeDevices/Smdn.TPSmartHomeDevices/src/Smdn.TPSmartHomeDevices.Primitives/bin/Release/net8.0/Smdn.TPSmartHomeDevices.Primitives.dll" target="lib/net8.0/Smdn.TPSmartHomeDevices.Primitives.dll" />
+    <file src="/home/runner/work/Smdn.TPSmartHomeDevices/Smdn.TPSmartHomeDevices/src/Smdn.TPSmartHomeDevices.Primitives/bin/Release/net8.0/Smdn.TPSmartHomeDevices.Primitives.xml" target="lib/net8.0/Smdn.TPSmartHomeDevices.Primitives.xml" />
+    <file src="/home/runner/work/Smdn.TPSmartHomeDevices/Smdn.TPSmartHomeDevices/src/Smdn.TPSmartHomeDevices.Primitives/bin/Release/netstandard2.0/Smdn.TPSmartHomeDevices.Primitives.dll" target="lib/netstandard2.0/Smdn.TPSmartHomeDevices.Primitives.dll" />
+    <file src="/home/runner/work/Smdn.TPSmartHomeDevices/Smdn.TPSmartHomeDevices/src/Smdn.TPSmartHomeDevices.Primitives/bin/Release/netstandard2.0/Smdn.TPSmartHomeDevices.Primitives.xml" target="lib/netstandard2.0/Smdn.TPSmartHomeDevices.Primitives.xml" />
+    <file src="/home/runner/work/Smdn.TPSmartHomeDevices/Smdn.TPSmartHomeDevices/src/Smdn.TPSmartHomeDevices.Primitives/bin/Release/netstandard2.1/Smdn.TPSmartHomeDevices.Primitives.dll" target="lib/netstandard2.1/Smdn.TPSmartHomeDevices.Primitives.dll" />
+    <file src="/home/runner/work/Smdn.TPSmartHomeDevices/Smdn.TPSmartHomeDevices/src/Smdn.TPSmartHomeDevices.Primitives/bin/Release/netstandard2.1/Smdn.TPSmartHomeDevices.Primitives.xml" target="lib/netstandard2.1/Smdn.TPSmartHomeDevices.Primitives.xml" />
+    <file src="/home/runner/work/Smdn.TPSmartHomeDevices/Smdn.TPSmartHomeDevices/.nuget/packages/smdn.msbuild.projectassets.common/1.4.0/project/images/package-icon.png" target="Smdn.TPSmartHomeDevices.Primitives.png" />
+    <file src="/home/runner/work/Smdn.TPSmartHomeDevices/Smdn.TPSmartHomeDevices/src/Smdn.TPSmartHomeDevices.Primitives/bin/Release/README.md" target="README.md" />
+  </files>
 </package>
\ No newline at end of file
```

