### PR TITLE
Release main/Smdn.TPSmartHomeDevices.Kasa-2.0.0

### DIFF
--- a/doc/api-list/Smdn.TPSmartHomeDevices.Kasa/Smdn.TPSmartHomeDevices.Kasa-net6.0.apilist.cs
+++ b/doc/api-list/Smdn.TPSmartHomeDevices.Kasa/Smdn.TPSmartHomeDevices.Kasa-net6.0.apilist.cs
@@ -1,7 +1,7 @@
-// Smdn.TPSmartHomeDevices.Kasa.dll (Smdn.TPSmartHomeDevices.Kasa-2.0.0-preview3)
+// Smdn.TPSmartHomeDevices.Kasa.dll (Smdn.TPSmartHomeDevices.Kasa-2.0.0)
 //   Name: Smdn.TPSmartHomeDevices.Kasa
 //   AssemblyVersion: 2.0.0.0
-//   InformationalVersion: 2.0.0-preview3+8f11224df269f7ecb743bef2e7c9b994a578c8dd
+//   InformationalVersion: 2.0.0+b94237e3ade205b0c2874616f6f9c9259586dcbd
 //   TargetFramework: .NETCoreApp,Version=v6.0
 //   Configuration: Release
 //   Referenced assemblies:

--- a/doc/api-list/Smdn.TPSmartHomeDevices.Kasa/Smdn.TPSmartHomeDevices.Kasa-net8.0.apilist.cs
+++ b/doc/api-list/Smdn.TPSmartHomeDevices.Kasa/Smdn.TPSmartHomeDevices.Kasa-net8.0.apilist.cs
@@ -1,7 +1,7 @@
-// Smdn.TPSmartHomeDevices.Kasa.dll (Smdn.TPSmartHomeDevices.Kasa-2.0.0-preview3)
+// Smdn.TPSmartHomeDevices.Kasa.dll (Smdn.TPSmartHomeDevices.Kasa-2.0.0)
 //   Name: Smdn.TPSmartHomeDevices.Kasa
 //   AssemblyVersion: 2.0.0.0
-//   InformationalVersion: 2.0.0-preview3+8f11224df269f7ecb743bef2e7c9b994a578c8dd
+//   InformationalVersion: 2.0.0+b94237e3ade205b0c2874616f6f9c9259586dcbd
 //   TargetFramework: .NETCoreApp,Version=v8.0
 //   Configuration: Release
 //   Referenced assemblies:

--- a/doc/api-list/Smdn.TPSmartHomeDevices.Kasa/Smdn.TPSmartHomeDevices.Kasa-netstandard2.1.apilist.cs
+++ b/doc/api-list/Smdn.TPSmartHomeDevices.Kasa/Smdn.TPSmartHomeDevices.Kasa-netstandard2.1.apilist.cs
@@ -1,7 +1,7 @@
-// Smdn.TPSmartHomeDevices.Kasa.dll (Smdn.TPSmartHomeDevices.Kasa-2.0.0-preview3)
+// Smdn.TPSmartHomeDevices.Kasa.dll (Smdn.TPSmartHomeDevices.Kasa-2.0.0)
 //   Name: Smdn.TPSmartHomeDevices.Kasa
 //   AssemblyVersion: 2.0.0.0
-//   InformationalVersion: 2.0.0-preview3+8f11224df269f7ecb743bef2e7c9b994a578c8dd
+//   InformationalVersion: 2.0.0+b94237e3ade205b0c2874616f6f9c9259586dcbd
 //   TargetFramework: .NETStandard,Version=v2.1
 //   Configuration: Release
 //   Referenced assemblies:


### PR DESCRIPTION
Automatically generated by workflow [Generate release target #31](https://github.com/smdn/Smdn.TPSmartHomeDevices/actions/runs/7628164675).

# Release target
- package_target_tag: `new-release/main/Smdn.TPSmartHomeDevices.Kasa-2.0.0`
- package_prevver_ref: `releases/Smdn.TPSmartHomeDevices.Kasa-2.0.0-preview3`
- package_prevver_tag: `releases/Smdn.TPSmartHomeDevices.Kasa-2.0.0-preview3`
- package_id: `Smdn.TPSmartHomeDevices.Kasa`
- package_id_with_version: `Smdn.TPSmartHomeDevices.Kasa-2.0.0`
- package_version: `2.0.0`
- package_branch: `main`
- release_working_branch: `releases/Smdn.TPSmartHomeDevices.Kasa-2.0.0-1706024306`
- release_tag: `releases/Smdn.TPSmartHomeDevices.Kasa-2.0.0`
- release_prerelease: `False` ❗Change this value to `true` to publish release note as a prerelease.
- release_draft: `false` ❗Change this value to `true` to publish release note as a draft.
- release_note_url: [`https://gist.github.com/smdn/72d3a6a2022d485cff56ac34b01ef0e0`](https://gist.github.com/smdn/72d3a6a2022d485cff56ac34b01ef0e0)
- artifact_name_nupkg: `Smdn.TPSmartHomeDevices.Kasa.2.0.0.nupkg` ❗Remove this line or change this value to empty to prevent publishing packages.

# .nuspec diff
```diff
--- Smdn.TPSmartHomeDevices.Kasa.latest.nuspec
+++ Smdn.TPSmartHomeDevices.Kasa.2.0.0.nuspec
@@ -1,33 +1,44 @@
 <?xml version="1.0" encoding="utf-8"?>
-<package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
+<package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
   <metadata>
     <id>Smdn.TPSmartHomeDevices.Kasa</id>
-    <version>2.0.0-preview3</version>
+    <version>2.0.0</version>
     <title>Smdn.TPSmartHomeDevices.Kasa</title>
     <authors>smdn</authors>
     <license type="expression">MIT</license>
     <licenseUrl>https://licenses.nuget.org/MIT</licenseUrl>
     <icon>Smdn.TPSmartHomeDevices.Kasa.png</icon>
     <readme>README.md</readme>
     <projectUrl>https://github.com/smdn/Smdn.TPSmartHomeDevices/</projectUrl>
     <description>Provides APIs for operating Kasa devices, the TP-Link smart home devices.</description>
-    <releaseNotes>https://github.com/smdn/Smdn.TPSmartHomeDevices/releases/tag/releases%2FSmdn.TPSmartHomeDevices.Kasa-2.0.0-preview3</releaseNotes>
+    <releaseNotes>https://github.com/smdn/Smdn.TPSmartHomeDevices/releases/tag/releases%2FSmdn.TPSmartHomeDevices.Kasa-2.0.0</releaseNotes>
     <copyright>Copyright © 2023 smdn</copyright>
     <tags>smdn.jp tplink-kasa,kasa,HS105,KL130,smarthome,homeautomation,smartdevice</tags>
-    <repository type="git" url="https://github.com/smdn/Smdn.TPSmartHomeDevices" branch="main" commit="8f11224df269f7ecb743bef2e7c9b994a578c8dd" />
+    <repository type="git" url="https://github.com/smdn/Smdn.TPSmartHomeDevices" commit="b94237e3ade205b0c2874616f6f9c9259586dcbd" />
     <dependencies>
       <group targetFramework="net6.0">
         <dependency id="Microsoft.Extensions.Logging.Abstractions" version="6.0.0" exclude="Build,Analyzers" />
-        <dependency id="Smdn.TPSmartHomeDevices.Primitives" version="1.1.0-preview3" exclude="Build,Analyzers" />
+        <dependency id="Smdn.TPSmartHomeDevices.Primitives" version="1.1.0" exclude="Build,Analyzers" />
       </group>
       <group targetFramework="net8.0">
         <dependency id="Microsoft.Extensions.Logging.Abstractions" version="6.0.0" exclude="Build,Analyzers" />
-        <dependency id="Smdn.TPSmartHomeDevices.Primitives" version="1.1.0-preview3" exclude="Build,Analyzers" />
+        <dependency id="Smdn.TPSmartHomeDevices.Primitives" version="1.1.0" exclude="Build,Analyzers" />
       </group>
       <group targetFramework=".NETStandard2.1">
         <dependency id="Microsoft.Extensions.Logging.Abstractions" version="6.0.0" exclude="Build,Analyzers" />
-        <dependency id="Smdn.TPSmartHomeDevices.Primitives" version="1.1.0-preview3" exclude="Build,Analyzers" />
+        <dependency id="Smdn.TPSmartHomeDevices.Primitives" version="1.1.0" exclude="Build,Analyzers" />
       </group>
     </dependencies>
   </metadata>
+  <files>
+    <file src="/home/runner/work/Smdn.TPSmartHomeDevices/Smdn.TPSmartHomeDevices/src/Smdn.TPSmartHomeDevices.Kasa/bin/Release/net6.0/Smdn.TPSmartHomeDevices.Kasa.dll" target="lib/net6.0/Smdn.TPSmartHomeDevices.Kasa.dll" />
+    <file src="/home/runner/work/Smdn.TPSmartHomeDevices/Smdn.TPSmartHomeDevices/src/Smdn.TPSmartHomeDevices.Kasa/bin/Release/net6.0/Smdn.TPSmartHomeDevices.Kasa.xml" target="lib/net6.0/Smdn.TPSmartHomeDevices.Kasa.xml" />
+    <file src="/home/runner/work/Smdn.TPSmartHomeDevices/Smdn.TPSmartHomeDevices/src/Smdn.TPSmartHomeDevices.Kasa/bin/Release/net8.0/Smdn.TPSmartHomeDevices.Kasa.dll" target="lib/net8.0/Smdn.TPSmartHomeDevices.Kasa.dll" />
+    <file src="/home/runner/work/Smdn.TPSmartHomeDevices/Smdn.TPSmartHomeDevices/src/Smdn.TPSmartHomeDevices.Kasa/bin/Release/net8.0/Smdn.TPSmartHomeDevices.Kasa.xml" target="lib/net8.0/Smdn.TPSmartHomeDevices.Kasa.xml" />
+    <file src="/home/runner/work/Smdn.TPSmartHomeDevices/Smdn.TPSmartHomeDevices/src/Smdn.TPSmartHomeDevices.Kasa/bin/Release/netstandard2.1/Smdn.TPSmartHomeDevices.Kasa.dll" target="lib/netstandard2.1/Smdn.TPSmartHomeDevices.Kasa.dll" />
+    <file src="/home/runner/work/Smdn.TPSmartHomeDevices/Smdn.TPSmartHomeDevices/src/Smdn.TPSmartHomeDevices.Kasa/bin/Release/netstandard2.1/Smdn.TPSmartHomeDevices.Kasa.xml" target="lib/netstandard2.1/Smdn.TPSmartHomeDevices.Kasa.xml" />
+    <file src="/home/runner/work/Smdn.TPSmartHomeDevices/Smdn.TPSmartHomeDevices/.nuget/packages/smdn.msbuild.projectassets.common/1.4.0/project/images/package-icon.png" target="Smdn.TPSmartHomeDevices.Kasa.png" />
+    <file src="/home/runner/work/Smdn.TPSmartHomeDevices/Smdn.TPSmartHomeDevices/ThirdPartyNotices.md" target="ThirdPartyNotices.md" />
+    <file src="/home/runner/work/Smdn.TPSmartHomeDevices/Smdn.TPSmartHomeDevices/src/Smdn.TPSmartHomeDevices.Kasa/bin/Release/README.md" target="README.md" />
+  </files>
 </package>
\ No newline at end of file
```

